### PR TITLE
CSS @import

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlCSSReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlCSSReplayRenderer.java
@@ -75,6 +75,7 @@ public class ArchivalUrlCSSReplayRenderer extends TextReplayRenderer {
 			}
 		}
 
-		page.insertAtStartOfDocument(toInsert.toString());
+//		page.insertAtStartOfDocument(toInsert.toString());
+		page.insertAtEndOfDocument( toInsert.toString() );
 	}
 }

--- a/wayback-core/src/main/java/org/archive/wayback/replay/TextDocument.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/TextDocument.java
@@ -275,6 +275,13 @@ public class TextDocument {
 	/**
 	 * @param toInsert
 	 */	
+	public void insertAtEndOfDocument( String toInsert ) {
+		sb.append( "\n" + toInsert );
+	}
+
+	/**
+	 * @param toInsert
+	 */	
 	public void insertAtStartOfHead(String toInsert) {
 		int insertPoint = TagMagix.getEndOfFirstTag(sb,"head");
 		if (-1 == insertPoint) {

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlCSSReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlCSSReplayRendererTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 
 import javax.servlet.http.HttpServletResponse;
 
+import junit.framework.Assert;
 import junit.framework.TestCase;
 
 import org.archive.io.warc.TestWARCReader;
@@ -135,7 +136,7 @@ public class ArchivalUrlCSSReplayRendererTest extends TestCase {
                 "  background: transparent url(/web/20100101123456/http://www.example.com/bg.gif);\n" +
                 "}\n";
         String out = servletOutput.getString();
-        assertEquals("servlet output", expected, out);        
+        Assert.assertTrue( out.startsWith( expected ) );
     }
     
     // TODO: more tests


### PR DESCRIPTION
For CSS that uses the @import syntax, the @import must appear first in the file.
