### PR TITLE
Re-enable the redirect URL field in generated CDXs

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/HTTPRecordAnnotater.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/HTTPRecordAnnotater.java
@@ -105,14 +105,10 @@ public class HTTPRecordAnnotater {
 					// right now, we're ignoring "Content-Location"
 					//
 					
-					// NOTE: FILLING THE REDIRECT FIELD IN CDX IS DISABLED!
-					// If we want to support redirect in cdx as long as the url is valid
-					// comment out the following lines:
-					
-					// String locationStr = httpHeader.getValue();
-					// result.setRedirectUrl(
-					//		UrlOperations.resolveUrl(result.getOriginalUrl(),
-					//				locationStr, "-"));
+					String locationStr = httpHeader.getValue();
+					result.setRedirectUrl(
+							UrlOperations.resolveUrl(result.getOriginalUrl(),
+									locationStr, "-"));
 
 				} else if(httpHeader.getName().toLowerCase().equals("content-type")) {
 					mimeType = transformHTTPMime(httpHeader.getValue());


### PR DESCRIPTION
This was disabled in d258e24c3775c4e7b6e557370e8a1cbd49f30248 however the field is required by SelfRedirectFilter in order to prevent redirect loops introduced by URL canonicalisation.

Fixes #114
