### PR TITLE
Turn off Javadoc lint for building with Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 		<website.url>http://github.com/iipc/openwayback</website.url>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<org.springframework.version>3.0.6.RELEASE</org.springframework.version>
+		<additionalparam>-Xdoclint:none</additionalparam>
 	</properties>
 
 	<description>


### PR DESCRIPTION
This turns off Javadoc lint in Java 8. The negative thing with this is that the warnings (issue #135) will be disabled. On the other hand, building with Java 8 will work. Apply if needed.
