### PR TITLE
Added maven profile for compiling with JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,18 @@
 		<module>dist</module>
 	</modules>
 
+	<profiles>
+          <profile>
+            <id>JDK 8 Build</id>
+            <activation>
+              <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+          </profile>
+        </profiles>
+
 	<properties>
 		<website.url>http://github.com/iipc/openwayback</website.url>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This adds  a maven profile for building with JDK 8. There is a single test-failure when building with JDK8, but I'll examine that and open a separate issue if necessary.
