### PR TITLE
Updated dependency on webarchive-commons to 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
 			<dependency>
 				<groupId>org.netpreserve.commons</groupId>
 				<artifactId>webarchive-commons</artifactId>
-				<version>1.1.2</version>
+				<version>1.1.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.netpreserve.openwayback</groupId>


### PR DESCRIPTION
The problem with uncompressed ARC's is solved in webarchive-commons, but the dependency was not updated.
