### PR TITLE
Fix for Issue #148: All dates should be independent of locale settings

### DIFF
--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/writer/MementoLinkWriter.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/writer/MementoLinkWriter.java
@@ -3,6 +3,7 @@ package org.archive.cdxserver.writer;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import javax.servlet.http.HttpServletRequest;
@@ -103,7 +104,7 @@ public class MementoLinkWriter extends HttpCDXWriter {
 	public final static TimeZone GMT_TZ = TimeZone.getTimeZone("GMT");
 
 	static {
-		HTTP_LINK_DATE_FORMATTER = new SimpleDateFormat(HTTP_LINK_DATE_FORMAT);
+		HTTP_LINK_DATE_FORMATTER = new SimpleDateFormat(HTTP_LINK_DATE_FORMAT, Locale.ENGLISH);
 		HTTP_LINK_DATE_FORMATTER.setTimeZone(GMT_TZ);
 	}
 	

--- a/wayback-core/src/main/java/org/archive/wayback/memento/MementoUtils.java
+++ b/wayback-core/src/main/java/org/archive/wayback/memento/MementoUtils.java
@@ -27,9 +27,9 @@ public class MementoUtils implements MementoConstants {
 	public final static SimpleDateFormat DATE_FORMAT_14_FORMATTER;
 
 	static {
-		HTTP_LINK_DATE_FORMATTER = new SimpleDateFormat(HTTP_LINK_DATE_FORMAT, Locale.US);
+		HTTP_LINK_DATE_FORMATTER = new SimpleDateFormat(HTTP_LINK_DATE_FORMAT, Locale.ENGLISH);
 		HTTP_LINK_DATE_FORMATTER.setTimeZone(GMT_TZ);
-		DATE_FORMAT_14_FORMATTER = new SimpleDateFormat(DATE_FORMAT_14, Locale.US);
+		DATE_FORMAT_14_FORMATTER = new SimpleDateFormat(DATE_FORMAT_14, Locale.ENGLISH);
 		DATE_FORMAT_14_FORMATTER.setTimeZone(GMT_TZ);
 	}
 	
@@ -271,9 +271,9 @@ public class MementoUtils implements MementoConstants {
 //	}
 
 	public static final SimpleDateFormat ACCEPT_DATE_FORMATS[] = {
-			new SimpleDateFormat("E, dd MMM yyyy HH:mm:ss Z", Locale.US),
-			new SimpleDateFormat("E, dd MMM yyyy Z", Locale.US),
-			new SimpleDateFormat("E, dd MMM yyyy", Locale.US) };
+			new SimpleDateFormat("E, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH),
+			new SimpleDateFormat("E, dd MMM yyyy Z", Locale.ENGLISH),
+			new SimpleDateFormat("E, dd MMM yyyy", Locale.ENGLISH) };
 
 	public static Date parseAcceptDateTimeHeader(String datespec) {
 		for (SimpleDateFormat format : ACCEPT_DATE_FORMATS) {

--- a/wayback-core/src/main/java/org/archive/wayback/util/partition/Partitioner.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/partition/Partitioner.java
@@ -25,6 +25,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.logging.Logger;
 
@@ -143,7 +144,7 @@ public class Partitioner<T> {
 	}
 	
 	private void logDates(String message, Date date1, Date date2) {
-		SimpleDateFormat f = new SimpleDateFormat("H:mm:ss:SSS MMM d, yyyy");
+		SimpleDateFormat f = new SimpleDateFormat("H:mm:ss:SSS MMM d, yyyy", Locale.ENGLISH);
 		f.setTimeZone(TZ_UTC);
 		String pd1 = f.format(date1);
 		String pd2 = f.format(date2);

--- a/wayback-core/src/test/java/org/archive/io/arc/TestARCReader.java
+++ b/wayback-core/src/test/java/org/archive/io/arc/TestARCReader.java
@@ -18,6 +18,7 @@ import org.archive.io.warc.WARCRecordInfo;
 import org.archive.util.DateUtils;
 
 import com.google.common.io.CountingInputStream;
+import java.util.Locale;
 
 /**
  * Fixture ARCReader.
@@ -55,7 +56,7 @@ public class TestARCReader extends ARCReader {
     
     private String isozToDateTime14(String isoz) {
         try {
-            Date d = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(isoz);
+            Date d = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ENGLISH).parse(isoz);
             return DateUtils.get14DigitDate(d);
         } catch (ParseException ex) {
             throw new RuntimeException("bad ISOZ: " + isoz, ex);

--- a/wayback-core/src/test/java/org/archive/wayback/resourcestore/resourcefile/WarcResourceTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/resourcestore/resourcefile/WarcResourceTest.java
@@ -4,6 +4,7 @@
 package org.archive.wayback.resourcestore.resourcefile;
 
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 import java.util.Map;
 
 import junit.framework.TestCase;
@@ -170,7 +171,7 @@ public class WarcResourceTest extends TestCase {
         // must have Date header, in HTTP Date format.
         String date = res.getHeader("Date");
         assertNotNull("has date header", date);
-        new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z").parse(date);
+        new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH).parse(date);
         
         // block as content
         byte[] buf = new byte[block.length + 1];
@@ -281,7 +282,7 @@ public class WarcResourceTest extends TestCase {
         // must have Date header, in HTTP Date format.
         String date = res.getHeader("Date");
         assertNotNull("has date header", date);
-        new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z").parse(date);
+        new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH).parse(date);
         
         res.close();
     }


### PR DESCRIPTION
Updates all creations of java.text.SimpleDateFormat to explicitly setting locale to ENGLISH.

Two unit tests will break until pull request https://github.com/iipc/webarchive-commons/pull/22 is applied.

Someone should double check for side effects before applying this.
