### PR TITLE
Added 'accessPointPath' to default proxy config.

### DIFF
--- a/wayback-webapp/src/main/webapp/WEB-INF/wayback.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/wayback.xml
@@ -308,6 +308,7 @@
     <property name="bounceToReplayPrefix" value="false" />
     <property name="bounceToQueryPrefix" value="false" />
     <property name="refererAuth" value="" />
+    <property name="accessPointPath" value="8090"/>
 
     <property name="staticPrefix" value="http://localhost:8090/" />
     <property name="replayPrefix" value="http://localhost:8090/" />


### PR DESCRIPTION
As mentioned on the [openwayback-dev](https://groups.google.com/forum/#!topic/openwayback-dev/6LSJd0872qo) mailing list, there seems to be a problem with proxy-mode in recent releases. Add the `accessPointPath` to the default config. resolves this.
