### PR TITLE
Updating GitHub site module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
                 <plugin>
                     <groupId>com.github.github</groupId>
                     <artifactId>site-maven-plugin</artifactId>
-                    <version>0.9</version>
+                    <version>0.10</version>
                 </plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Validation checks for submissions to the GitHub API has changed. This made GitHub site module fail. A quick-fix was made in 0.10, but introduced the requirement of setting username and public email address in your GitHub profile. Hopefully there will soon be another update which uses locally set email address avoiding the need to have a public email address in the profile.
