### PR TITLE
Add a system to manage specific rules for some URL (spring configurable)

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/util/url/AggressiveUrlCanonicalizer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/url/AggressiveUrlCanonicalizer.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -175,6 +176,16 @@ public class AggressiveUrlCanonicalizer implements UrlCanonicalizer {
 			STRIP_SID_REGEX,
 			STRIP_CFSESSION_REGEX 
     };
+	
+	private List<CanonicalizationRule> processingRules = new ArrayList<CanonicalizationRule>();
+	
+	public List<CanonicalizationRule> getProcessingRules() {
+	    return processingRules;
+    }
+
+    public void setProcessingRules(List<CanonicalizationRule> processingRules) {
+        this.processingRules = processingRules;
+    }
 
     /**
      * Run a regex against a StringBuilder, removing group 1 if it matches.
@@ -211,6 +222,14 @@ public class AggressiveUrlCanonicalizer implements UrlCanonicalizer {
 		} else {
 			searchUrl = scheme + searchUrl;
 		}
+
+        // Custom rules
+
+        for (CanonicalizationRule rule : getProcessingRules()) {
+            searchUrl = rule.processIfMatches(new CanonicalizationInput(searchUrl));
+        }
+
+        // Core rules
 
 		// TODO: These next few lines look crazy -- need to be reworked.. This
 		// was the only easy way I could find to get the correct unescaping

--- a/wayback-core/src/main/java/org/archive/wayback/util/url/CanonicalizationInput.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/url/CanonicalizationInput.java
@@ -1,0 +1,21 @@
+/**
+ *
+ */
+package org.archive.wayback.util.url;
+
+/**
+ * @author ngiraud
+ *
+ */
+public class CanonicalizationInput extends UriMatchRuleInput {
+
+    CanonicalizationInput(String uri) {
+        super(uri);
+    }
+
+    @Override
+    public String getTextToProcess() {
+        return getUri();
+    }
+
+}

--- a/wayback-core/src/main/java/org/archive/wayback/util/url/CanonicalizationRule.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/url/CanonicalizationRule.java
@@ -1,0 +1,12 @@
+/**
+ *
+ */
+package org.archive.wayback.util.url;
+
+/**
+ * @author ngiraud
+ *
+ */
+public class CanonicalizationRule extends UriMatchRule<CanonicalizationInput> {
+
+}

--- a/wayback-core/src/main/java/org/archive/wayback/util/url/PatternBasedTextProcessor.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/url/PatternBasedTextProcessor.java
@@ -1,0 +1,62 @@
+/**
+ *
+ */
+package org.archive.wayback.util.url;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A generic abstract pattern-based string processor.
+ *
+ * The implementing classes are expected to be Spring beans.
+ *
+ * @see UriMatchRule
+ *
+ * @author ngiraud
+ *
+ */
+public abstract class PatternBasedTextProcessor {
+
+    /**
+     * The pattern to find in the input.
+     */
+    private String pattern;
+
+    /**
+     * The underlying pattern implementation.
+     */
+    private Pattern patternImpl;
+
+    /**
+     * @return the pattern to match against the input.
+     */
+    public final String getPattern() {
+        return pattern;
+    }
+
+    /**
+     * @param pattern the pattern to match against the input.
+     */
+    public final void setPattern(final String pattern) {
+        this.pattern = pattern;
+        this.patternImpl = Pattern.compile(pattern);
+    }
+
+    /**
+     * Processes a given text.
+     * @param text the text to process.
+     * @return the text after processing
+     */
+    public abstract String process(final String text);
+
+    /**
+     * Builds a matcher for the given text.
+     * @param text the text to match against the pattern.
+     * @return the matcher
+     */
+    protected final Matcher getMatcher(final String text) {
+        return patternImpl.matcher(text);
+    }
+
+}

--- a/wayback-core/src/main/java/org/archive/wayback/util/url/UriMatchRule.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/url/UriMatchRule.java
@@ -1,0 +1,108 @@
+/**
+ *
+ */
+package org.archive.wayback.util.url;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Base abstract class that defines a regexp based URI processor.
+ * A rule will execute an operation provided that the candidate URI partially matches the
+ * configured pattern.
+ *
+ * TODO instead of simply returning the processed URI, we should add a wrapper object that
+ * also contains an enum value that would allow to control the sequence of rules,
+ * something like Hetrix scoping rules.
+ *
+ * @author ngiraud
+ *
+ * @param <I> the class of input.
+ */
+public class UriMatchRule<I extends UriMatchRuleInput> {
+
+    /**
+     * The class logger.
+     */
+    private static final Logger LOGGER =
+            Logger.getLogger(UriMatchRule.class.getName());
+
+    /**
+     * The match pattern.
+     */
+    private String pattern;
+
+    /**
+     * The list of processors.
+     */
+    private List<PatternBasedTextProcessor> processors;
+
+    /**
+     * The underlying pattern implementation.
+     */
+    private Pattern patternImpl;
+
+    /**
+     * @return the match pattern
+     */
+    public String getPattern() {
+        return pattern;
+    }
+
+    /**
+     * @return the list of processors.
+     */
+    public List<PatternBasedTextProcessor> getProcessors() {
+        return processors;
+    }
+
+    /**
+     * @param processors the list of processors.
+     */
+    public void setProcessors(List<PatternBasedTextProcessor> processors) {
+        this.processors = processors;
+    }
+
+    /**
+     * @param pattern the pattern to set
+     */
+    public void setPattern(final String pattern) {
+        this.pattern = pattern;
+        this.patternImpl = Pattern.compile(pattern);
+    }
+
+    /**
+     * Processes the given URI if it matches the configured pattern.
+     * @param uriAsString the candidate URI as string
+     * @param context the execution context
+     * @return the URI after processing
+     */
+    public String processIfMatches(final I input) {
+        String uriAsString = input.getUri();
+        String text = input.getTextToProcess();
+        Matcher m = patternImpl.matcher(uriAsString);
+        if (!m.find()) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine("Rule " + getClass().getSimpleName()
+                        + ": skipped " + uriAsString);
+            }
+            return text;
+        }
+
+        String result = new String(text);
+        for (PatternBasedTextProcessor proc : processors) {
+            result = proc.process(result);
+        }
+
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine("Rule " + getClass().getSimpleName()
+                    + ": processed " + uriAsString);
+        }
+
+        return result;
+    }
+
+}

--- a/wayback-core/src/main/java/org/archive/wayback/util/url/UriMatchRuleInput.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/url/UriMatchRuleInput.java
@@ -1,0 +1,39 @@
+/**
+ *
+ */
+package org.archive.wayback.util.url;
+
+/**
+ * Abstract class used to wrap input for the execution of an {@link UriMatchRule}.
+ *
+ * @author ngiraud
+ *
+ */
+abstract class UriMatchRuleInput {
+
+    /**
+     * The URI to test.
+     */
+    private final String uri;
+
+    /**
+     * Constructor from URI.
+     * @param uri the URI to test
+     */
+    protected UriMatchRuleInput(String uri) {
+        this.uri = uri;
+    }
+
+    /**
+     * @return the URI to test
+     */
+    public String getUri() {
+        return uri;
+    }
+
+    /**
+     * @return the text to be processed by rule processors.
+     */
+    public abstract String getTextToProcess();
+
+}

--- a/wayback-core/src/main/java/org/archive/wayback/util/url/UriStripper.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/url/UriStripper.java
@@ -1,0 +1,30 @@
+/**
+ *
+ */
+package org.archive.wayback.util.url;
+
+import java.util.regex.Matcher;
+
+/**
+ *
+ * @author ngiraud
+ *
+ */
+public class UriStripper extends PatternBasedTextProcessor {
+
+    public UriStripper() {
+        super();
+    }
+
+    @Override
+    public String process(final String uriAsString) {
+        Matcher m = getMatcher(uriAsString);
+        StringBuffer result = new StringBuffer();
+        while (m.find()) {
+            m.appendReplacement(result, "");;
+        }
+        m.appendTail(result);
+        return result.toString();
+    }
+
+}

--- a/wayback-core/src/main/java/org/archive/wayback/util/url/UriTranscoder.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/url/UriTranscoder.java
@@ -1,0 +1,67 @@
+/**
+ *
+ */
+package org.archive.wayback.util.url;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+
+/**
+ *
+ * Transcode the first group in the matched pattern.
+ *
+ * TODO make group(s) configurable.
+ *
+ * @author ngiraud
+ *
+ */
+public class UriTranscoder extends PatternBasedTextProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(UriTranscoder.class.getName());
+
+    private String sourceEncoding;
+
+    private String targetEncoding;
+
+    public String getSourceEncoding() {
+        return sourceEncoding;
+    }
+
+    public void setSourceEncoding(String sourceEncoding) {
+        this.sourceEncoding = sourceEncoding;
+    }
+
+    public String getTargetEncoding() {
+        return targetEncoding;
+    }
+
+    public void setTargetEncoding(String targetEncoding) {
+        this.targetEncoding = targetEncoding;
+    }
+
+    @Override
+    public String process(final String uriAsString) {
+        Matcher m = getMatcher(uriAsString);
+        StringBuilder result = new StringBuilder(uriAsString);
+        while (m.find()) {
+            int start = m.start(1);
+            int end = m.end(1);
+            try {
+                String decodedGroup = URLDecoder.decode(
+                        uriAsString.substring(start, end), getSourceEncoding());
+                result.replace(
+                        start,
+                        end,
+                        URLEncoder.encode(decodedGroup, getTargetEncoding()));
+            } catch (UnsupportedEncodingException e) {
+                LOGGER.log(Level.SEVERE, e.getLocalizedMessage(), e);
+            }
+        }
+        return result.toString();
+    }
+
+}

--- a/wayback-webapp/src/main/webapp/WEB-INF/wayback.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/wayback.xml
@@ -27,7 +27,31 @@
     </property>
   </bean>
 
-  <bean id="waybackCanonicalizer" class="org.archive.wayback.util.url.AggressiveUrlCanonicalizer" />
+  <bean id="waybackCanonicalizer" class="org.archive.wayback.util.url.AggressiveUrlCanonicalizer">
+    <!-- some specific canonicalization rules to apply to URLS matching a particular pattern -->
+    <property name="processingRules">
+      <list>
+        <!-- Ouest France -->
+        <!--
+        <bean class="org.archive.wayback.util.url.CanonicalizationRule">
+          <property name="pattern" value="ouestfrance-enligne\.com" />
+          <property name="processors">
+            <list>
+              <bean class="org.archive.wayback.util.url.UriStripper">
+                <property name="pattern" value="(in_ses_id=[0-9]+)&amp;?" />
+              </bean>
+              <bean class="org.archive.wayback.util.url.UriTranscoder">
+                <property name="pattern" value="&amp;edi=(.+)&amp;" />
+                <property name="sourceEncoding" value="ISO-8859-1" />
+                <property name="targetEncoding" value="UTF-8" />
+              </bean>
+            </list>
+          </property>
+        </bean>
+        -->
+      </list>
+    </property>
+  </bean>
 
 
 <!--


### PR DESCRIPTION
Hello everyone,

As we are discuting about the future of the OpenWayback project, the BnF would like to present you a small feature that could maybe interest some of you and could be add to the openwayback project.

This feature has been developed by Nicolas Giraud, the previous software engineer of the BnF web archive team. This feature provides a system to manage specific canonicalization rules on URL. For instance, we have a news website which have session id in URLs and we want to remove it during the search and replay process.

The URLs looks like :
http://www.ouestfrance-enligne.com/scripts/consult/pdf/PDF_frame.asp?in_ses_id=2047240875806&pdf=S2192220&date=09/09/2014&art_id=68159490&zoom=125,11,78


We define the rules in Spring :
```
<bean class="org.archive.wayback.util.url.BnfUrlCanonicalizer" id="bnfCanonicalizer">
    <property name="processingRules">
		<list>
			<!-- Ouest France -->
			<bean class="org.archive.wayback.util.url.CanonicalizationRule">
				<property name="pattern" value="ouestfrance-enligne\.com" />
				<property name="processors">
					<list>
						<bean class="org.archive.wayback.util.url.UriStripper">
							<property name="pattern" value="(in_ses_id=[0-9]+)&amp;?" />
						</bean>
						<bean class="org.archive.wayback.util.url.UriTranscoder">
							<property name="pattern" value="&amp;edi=(.+)&amp;" />
							<property name="sourceEncoding" value="ISO-8859-1" />
							<property name="targetEncoding" value="UTF-8" />
						</bean>
					</list>
				</property>
			</bean>
		</list>
	</property>
</bean>
```
- BnfUrlCanonicalizer simply extends AggressiveUrlCanonicalizer
- we have a processingRules property which is a list of canonicalization rules
- A CanonicalizationRule is a pattern, in our case it's a specific domain (ouestfrance-enligne.com), and a list of processors that will only process when some input URL matchs this pattern.
- the processors could be from several types, but all extends PatternBasedTextProcessor abstract class :
	* UriStripper remove the specific pattern in an input URL
	* UriTranscoder transcode the matching part of an URL from a encoding to an other
	

In this example, we want to remove the in_ses_id attribut, so we use a UriStripper processor with the corresponding pattern.
Then we also want to transcode an another attribute that cause trouble, from ISO-8859-1 to UTF-8 so we use the UriTranscoder with the right pattern.

In BnfUrlCanonicalizer, we override urlStringToKey method from AggressiveUrlCanonicalizer, adding :
```
for (CanonicalizationRule rule : getProcessingRules()) {
    searchUrl = rule.processIfMatches(new CanonicalizationInput(searchUrl));
}
```
which will transform the URL in case of match.

We could give to the OpenWayback project all the classes needed to run this functionality.