### PR TITLE
Fix for issue #116

### DIFF
--- a/wayback-webapp/src/main/webapp/WEB-INF/LiveWeb.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/LiveWeb.xml
@@ -34,7 +34,10 @@
     <property name="proxyHostPort" value="localhost:8099" />
 <!--
 	If you've set up a local squid/varnish to cache requests to the above 
-	ARCRecordingProxy, you should use the port for that, instead of 8099:
+	ARCRecordingProxy, it is preferable to use RemoteLiveWebCache2 instead and
+	you should use the port for that e.g. 3128, instead of 8099:
+  <bean id="proxylivewebcache"
+      class="org.archive.wayback.liveweb.RemoteLiveWebCache2">
     <property name="proxyHostPort" value="localhost:3128" />
 -->
   </bean>


### PR DESCRIPTION
If you've set up a squid and used it with RemoteLiveWebCache2, you can freely comment out other beans. This will not affect LiveWeb.xml main functionality.