### PR TITLE
Moved SWFReplayRenderer to external file.

### DIFF
--- a/src/site/xdoc/release_notes.xml
+++ b/src/site/xdoc/release_notes.xml
@@ -27,6 +27,7 @@
           <li>Fixed building with JDK 8. <a href="https://github.com/iipc/openwayback/pull/141">#141</a></li>
           <li>Removed direct references to Unix spesific TMP paths /tmp and /var/tmp. <a href="https://github.com/iipc/openwayback/issues/172">#172</a></li>
           <li>Initial thread-safety fix for Memento from Luda. <a href="https://github.com/iipc/openwayback/issues/180">#180</a></li>
+          <li>Moved 'SWFReplayRenderer' to external file; imported to maintain functionality. <a href="https://github.com/iipc/openwayback/issues/176">#176</a></li>
         </ul>
       </subsection>
     </section>

--- a/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlReplay.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlReplay.xml
@@ -150,21 +150,9 @@
           </property>
           <property name="renderer" ref="archivalsaxreplayrenderer"/>
         </bean>
-        
-        <!-- SWF Rewriting, highly experimental -->
-        <bean class="org.archive.wayback.replay.selector.MimeTypeSelector">
-          <property name="mimeContains">
-            <list>
-              <value>application/x-shockwave-flash</value>
-            </list>
-          </property>
-          <property name="renderer">
-            <bean class="org.archive.wayback.replay.swf.SWFReplayRenderer">
- 	          <constructor-arg><ref bean="archivalurlhttpheaderprocessor"/></constructor-arg>
-            </bean>
-          </property>
-        </bean>
 
+        <import resource="SWFReplayRenderer.xml"/>
+        
         <!-- CSS REPLAY -->
         <bean class="org.archive.wayback.replay.selector.MimeTypeSelector">
           <property name="mimeContains">

--- a/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlReplay.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlReplay.xml
@@ -96,6 +96,9 @@
     <property name="delegator" ref="fastArchivalSAXDelegator"/>
   </bean>
 
+  <!-- SWF Rewriting, highly experimental -->
+  <import resource="SWFReplayRenderer.xml"/>
+
 <!-- 
 	The main Archival URL replay dispatcher. It uses a list of Selectors to
 	determine which ReplayRenderer should be used for each document.
@@ -151,7 +154,8 @@
           <property name="renderer" ref="archivalsaxreplayrenderer"/>
         </bean>
 
-        <import resource="SWFReplayRenderer.xml"/>
+        <!-- SWF Rewriting, highly experimental -->
+        <ref bean="swfreplay" />
         
         <!-- CSS REPLAY -->
         <bean class="org.archive.wayback.replay.selector.MimeTypeSelector">

--- a/wayback-webapp/src/main/webapp/WEB-INF/SWFReplayRenderer.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/SWFReplayRenderer.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
@@ -5,7 +6,7 @@
         default-init-method="init">
 
     <!-- SWF Rewriting, highly experimental -->
-    <bean class="org.archive.wayback.replay.selector.MimeTypeSelector">
+    <bean id="swfreplay" class="org.archive.wayback.replay.selector.MimeTypeSelector">
       <property name="mimeContains">
         <list>
           <value>application/x-shockwave-flash</value>

--- a/wayback-webapp/src/main/webapp/WEB-INF/SWFReplayRenderer.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/SWFReplayRenderer.xml
@@ -1,0 +1,21 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
+        default-init-method="init">
+
+    <!-- SWF Rewriting, highly experimental -->
+    <bean class="org.archive.wayback.replay.selector.MimeTypeSelector">
+      <property name="mimeContains">
+        <list>
+          <value>application/x-shockwave-flash</value>
+        </list>
+      </property>
+      <property name="renderer">
+        <bean class="org.archive.wayback.replay.swf.SWFReplayRenderer">
+          <constructor-arg><ref bean="archivalurlhttpheaderprocessor"/></constructor-arg>
+        </bean>
+      </property>
+    </bean>
+</beans>
+


### PR DESCRIPTION
SWFReplayRenderer moved to an external file, fixin #176 . I've left it as part of the configuration via  `<import resource="SWFReplayRenderer.xml"/>` in order to maintain consistency in the default config.