### PR TITLE
BUGFIX: Rewrite @import URL in HTML comment

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
@@ -124,9 +124,16 @@ public class FastArchivalUrlReplayParseEventHandler implements
 	public void handleNode(ParseContext pContext, Node node) throws IOException {
 		ReplayParseContext context = (ReplayParseContext)pContext;
 		if (NodeUtils.isRemarkNode(node)) {
+			// HTML Comment - often used in JAVASCRIPT/STYLE element
+			// to hide its content on old browsers.
 			RemarkNode remarkNode = (RemarkNode)node;
-			remarkNode.setText(jsBlockTrans.transform(context,
-				remarkNode.getText()));
+			if (context.isInCSS()) {
+				remarkNode.setText(cssBlockTrans.transform(context,
+					remarkNode.getText()));
+			} else {
+				remarkNode.setText(jsBlockTrans.transform(context,
+					remarkNode.getText()));
+			}
 			emit(context, null, node, null);
 
 		} else if (NodeUtils.isTextNode(node)) {

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
@@ -165,6 +165,30 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
         assertEquals(expected, out);
 	}
 
+	/**
+	 * Some people enclose in-line STYLE content with HTML Comment
+	 * for better support for stone age browsers.
+	 * @throws Exception
+	 */
+	public void testStyleElmeentImportUrlInsideHTMLComment() throws Exception {
+        final String input = "<html>" +
+                "<head>" +
+                "<style type=\"text/css\">\n" +
+				"<!-- @import '/shared.css'; -->\n" +
+				"</style>" +
+                "</head>" +
+                "</html>";
+        final String expected = "<html>" +
+                "<head>" +
+                "<style type=\"text/css\">\n" +
+				"<!-- @import 'http://replay.archive.org/2001cs_/http://www.example.com/shared.css'; -->\n" + 
+				"</style>" +
+                "</head>" +
+                "</html>";
+        String out = doEndToEnd(input);
+        assertEquals(expected, out);
+	}
+
     public void testStyleElementFontfaceSrcUrl() throws Exception {
         // font data is not an image technically, but it'd require more elaborate
         // pattern match to differentiate a context of url function. use im_ for


### PR DESCRIPTION
`FastArchivalUrlReplayParseEventHandler` processes text enclosed with HTML comment as JavaScript even when it happens in CSS. As a result, url(...) in CSS are not rewritten.

This patch fixes the bug - resolves #131