### PR TITLE
Update release notes with IA change descriptions

### DIFF
--- a/src/site/xdoc/release_notes.xml
+++ b/src/site/xdoc/release_notes.xml
@@ -20,10 +20,28 @@
       <subsection name="Features">
        <ul>
           <li>Synchronised with latest changes from the Internet Archive fork. <a href="https://github.com/iipc/openwayback/pull/195">#195</a></li>
+          <li>URL-decode timestamp segment of replay URL. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/23">internetarchive#23</a></li>
+          <li>Revisits can be resolved with excluded capture <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/65">internetarchive#65</a></li>
+          <li>Added rudimentary mime-type sniffing (work in progress). <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/46">internetarchive#46</a></li>
+          <li>Timestamp-collapsing can be configured to return the last best capture in eacho collapse group. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/64">internetarchive#64</a></li>
+          <li>UIResults now has makePlainCaptureQueryUrl() method for generating clean, short URL for capture query links. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/60">internetarchive#60</a></li>
+          <li>MultipleRegexReplaceStringTransformer may also be used as RewriteRule. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/54">internetarchive#54</a></li>
+          <li>Allow for using different collapseTime for replay and capture search <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/49">internetarchive#49</a></li>
+          <li>Make collection-dependent exclusion configurable. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/48">internetarchive#48</a></li>
+          <li>Removed CustomUserResourceIndex class, which does not appear to have broad utility. <a href="https://github.com/iipc/openwayback/pull/195">#195</a></li>
+          <li>Performance information in response header can now be in JSON format. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/69">internetarchive#69</a></li>
+          <li>FastArchivalUrlReplayParseEventHandler no longer rewrite relative URLs for better replay quality. <a href="https://github.com/iipc/openwayback/pull/195">#195</a></li> 
        </ul>
       </subsection>
       <subsection name="Bug Fixes">
         <ul>
+          <li>Fixed incorrect Content-Type in replay of resource record with JWATFlexResource <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/68">internetarchive#68</a></li>
+          <li>Fixed ClassCastException when JWATFlexResourceStore is in use <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/67">internetarchive#67</a></li>
+          <li>Pass-through Content-Range header field for audio playback to work <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/66"></li>
+          <li>Fixed undesirable rewrite of in-page (fragment-only) links. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/63"></li>
+          <li>Fixed XHTML parse error due to banner insert before XML declaration. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/61">internetarchive#61</a></li>
+          <li>Fixed PrivTokenAuthChecker resetting ignoreRobots. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/51">internetarchive#51</a></li>
+          <li>Made CharsetDetector adher to WHAT-NG recommendation. <a href="https://github.com/iipc/openwayback/pull/195">#195</a>, <a href="https://github.com/internetarchive/wayback/issues/47">internetarchive#47</a></li>
           <li>Fixed building with JDK 8. <a href="https://github.com/iipc/openwayback/pull/141">#141</a></li>
           <li>NullPointerException for RemoteResourceIndex <a href="https://github.com/iipc/openwayback/issues/193">#193</a></li>
           <li>Removed direct references to Unix specific TMP paths /tmp and /var/tmp. <a href="https://github.com/iipc/openwayback/issues/172">#172</a></li>


### PR DESCRIPTION
Added a descriptions of IA changes merged in 1dbd4f3, to openwayback release notes.  For each item, I put a link to internetarchive issue describing the details of the change, if available.  Perhaps overkill? 

Please feel free to make further changes if necessary.