### PR TITLE
WatchedCDXSource; replacement for #184.

### DIFF
--- a/src/site/xdoc/release_notes.xml
+++ b/src/site/xdoc/release_notes.xml
@@ -16,6 +16,13 @@
         Full listing of changes and bug fixes are not available prior to release 1.2.0 and between release 1.6.0 and OpeWayback 2.0.0 BETA 1 release. 
       </p>
     </section>
+    <section name="OpenWayback 2.2.0 Release">
+      <subsection name="Features">
+       <ul>
+          <li>WatchedCDXSource now monitors directories for new CDX files. <a href="https://github.com/iipc/openwayback/pull/181">#181</a></li>
+       </ul>
+      </subsection>
+    </section>
     <section name="OpenWayback 2.1.0 Release">
       <subsection name="Features">
        <ul>

--- a/wayback-core/src/main/java/org/archive/wayback/resourceindex/WatchedCDXSource.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourceindex/WatchedCDXSource.java
@@ -1,0 +1,146 @@
+package org.archive.wayback.resourceindex;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.archive.wayback.resourceindex.cdx.CDXIndex;
+
+/**
+ * SearchResultSource that watches a single directory for new
+ * SearchResultSources.
+ * 
+ * @author rcoram
+ * 
+ */
+
+public class WatchedCDXSource extends CompositeSearchResultSource {
+    private static final Logger LOGGER = Logger
+        .getLogger(WatchedCDXSource.class.getName());
+    private Thread watcherThread;
+    private Path path;
+
+    public void setPath(String path) {
+    this.path = Paths.get(path);
+    if (watcherThread == null) {
+        try {
+        watcherThread = new WatcherThread(this.path);
+        } catch (IOException e) {
+        LOGGER.log(Level.SEVERE,
+            "Could not watch CDX directory: " + e.getMessage(), e);
+        }
+        watcherThread.start();
+    }
+    try {
+        addExistingSources(this.path);
+    } catch (IOException e) {
+        LOGGER.log(Level.SEVERE,
+            "Could not add existing CDXs: " + e.getMessage(), e);
+    }
+    }
+
+    public String getPath(){
+    return this.path.toString();
+    }
+
+    /**
+     * adds already-existing SearchResultSource in the watched directory
+     * 
+     * @param path
+     * @throws IOException
+     */
+    private void addExistingSources(Path path) throws IOException {
+    DirectoryStream<Path> directoryStream = Files.newDirectoryStream(path);
+    for (Path file : directoryStream) {
+        CDXIndex index = new CDXIndex();
+        index.setPath(file.toString());
+        LOGGER.info("Adding CDX: " + index.getPath());
+        addSource(index);
+    }
+    }
+
+    /**
+     * removes a SearchResultSource upon from the list of sources.
+     * 
+     * @param deleted
+     * @return
+     */
+    public boolean removeSource(SearchResultSource deleted) {
+    return sources.remove(deleted);
+    }
+
+    /**
+     * Monitors a directory for ENTRY_CREATE events, creating
+     * SearchResultSources.
+     * 
+     * @author rcoram
+     * 
+     */
+    private class WatcherThread extends Thread {
+    private final WatchService watcher;
+    private final Path dir;
+
+    public WatcherThread(Path path) throws IOException {
+        this.dir = path;
+        this.watcher = FileSystems.getDefault().newWatchService();
+        dir.register(watcher, ENTRY_CREATE, ENTRY_DELETE);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void run() {
+        while (true) {
+        WatchKey key;
+        try {
+            key = watcher.take();
+        } catch (InterruptedException x) {
+            return;
+        }
+
+        for (WatchEvent<?> event : key.pollEvents()) {
+            WatchEvent.Kind kind = event.kind();
+
+            if (kind == ENTRY_CREATE) {
+            WatchEvent<Path> ev = (WatchEvent<Path>) event;
+            Path cdx = dir.resolve(ev.context());
+            LOGGER.info("Adding new CDX " + cdx);
+            CDXIndex index = new CDXIndex();
+            index.setPath(cdx.toString());
+            LOGGER.info("Adding CDX: " + index.getPath());
+            addSource(index);
+            }
+
+            if (kind == ENTRY_DELETE) {
+            WatchEvent<Path> ev = (WatchEvent<Path>) event;
+            Path cdx = dir.resolve(ev.context());
+            LOGGER.info("Removing CDX " + cdx);
+            CDXIndex index = new CDXIndex();
+            index.setPath(cdx.toString());
+            if (!removeSource(index)) {
+                LOGGER.info("CDX " + cdx
+                    + " not found in list of sources.");
+            }
+            }
+        }
+
+        // "If the key is no longer valid, the directory is inaccessible
+        // so exit the loop."
+        boolean valid = key.reset();
+        if (!valid) {
+            break;
+        }
+        }
+    }
+    }
+}
+

--- a/wayback-core/src/test/java/org/archive/wayback/resourceindex/WatchedCDXSourceTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/resourceindex/WatchedCDXSourceTest.java
@@ -1,0 +1,114 @@
+package org.archive.wayback.resourceindex;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import junit.framework.TestCase;
+
+public class WatchedCDXSourceTest extends TestCase {
+    WatchedCDXSource cdxSource;
+    Path cdxDir;
+
+    @Override
+    protected void setUp() {
+    cdxSource = new WatchedCDXSource();
+
+    String tmp = System.getProperty("java.io.tmpdir");
+    cdxDir = Paths.get(tmp + File.separator
+        + Long.toString(System.nanoTime()));
+    try {
+        cdxDir = Files.createDirectory(cdxDir);
+    } catch (IOException e) {
+        fail("Error creating CDX directory: " + e.getMessage());
+    }
+    }
+
+    private void addCdx() {
+    try {
+        Files.createTempFile(cdxDir, Long.toString(System.nanoTime()),
+            ".cdx");
+    } catch (IOException e) {
+        fail("Error creating CDX file: " + e.getMessage());
+    }
+    }
+
+    @SuppressWarnings("unused")
+    private int countCDXs() {
+    int count = 0;
+    try {
+        for (Path p : Files.newDirectoryStream(cdxDir)) {
+        count++;
+        }
+    } catch (IOException e) {
+        fail("Error reading CDX directory: " + e.getMessage());
+    }
+    return count;
+    }
+
+    /**
+     * Test method for
+     * {@link org.archive.wayback.resourceindex.WatchedCDXSource#addExistingSources(java.nio.file.Path)}
+     * .
+     * 
+     * @throws IOException
+     * 
+     */
+    public void testExistingSources() throws IOException {
+    addCdx();
+    cdxSource.setPath(cdxDir.toString());
+    assertEquals(1, cdxSource.sources.size());
+    }
+
+    /**
+     * Test method for
+     * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
+     * .
+     * 
+     * @throws InterruptedException
+     * 
+     */
+    public void testAddSources() throws InterruptedException {
+    cdxSource.setPath(cdxDir.toString());
+    for (int i = 0; i < 10; i++) {
+        addCdx();
+        Thread.sleep(100L);
+        assertEquals(countCDXs(), cdxSource.getSources().size());
+    }
+    }
+
+    /**
+     * Test method for
+     * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
+     * .
+     * @throws InterruptedException 
+     * 
+     */
+    public void testRemoveSources() throws InterruptedException {
+    cdxSource.setPath(cdxDir.toString());
+    try {
+        for (Path p : Files.newDirectoryStream(cdxDir)) {
+        Files.delete(p);
+        Thread.sleep(100L);
+        assertEquals(countCDXs(), cdxSource.sources.size());
+        }
+    } catch (IOException e) {
+        fail("Error deleting CDX file: " + e.getMessage());
+    }
+    }
+
+    @Override
+    protected void tearDown() {
+    try {
+        for (Path p : Files.newDirectoryStream(cdxDir)) {
+        Files.delete(p);
+        }
+        Files.delete(cdxDir);
+    } catch (IOException e) {
+        fail("Error deleting CDX directory: " + e.getMessage());
+    }
+    }
+}
+


### PR DESCRIPTION
As per #184, code for the new `WatchedCDXSource`:

    <property name="resourceIndex">
        <bean class="org.archive.wayback.resourceindex.LocalResourceIndex">
            <property name="canonicalizer" ref="waybackCanonicalizer" />
            <property name="source">
                <bean class="org.archive.wayback.resourceindex.WatchedCDXSource">
                    <property name="path" value="${wayback.basedir}/cdx-index/" />
                </bean>
            </property>
            <property name="maxRecords" value="10000" />
            <property name="dedupeRecords" value="true" />    
        </bean>
    </property>