### PR TITLE
Prevented start/end dates being nullified...

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/requestparser/ArchivalUrlFormRequestParser.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/requestparser/ArchivalUrlFormRequestParser.java
@@ -46,10 +46,14 @@ public class ArchivalUrlFormRequestParser extends FormRequestParser {
 		if (wbRequest != null) {
 			String replayTimestamp = wbRequest.getReplayTimestamp();
 			if ((replayTimestamp == null) || replayTimestamp.length() == 0) {
-				// lets call it a star query:
-				// TODO: should we clone?
-				wbRequest.setStartTimestamp(null);
-				wbRequest.setEndTimestamp(null);
+				// If it's not a capture or URL query, let's call it a star
+				// query:
+				if (!(wbRequest.isCaptureQueryRequest() || wbRequest
+						.isUrlQueryRequest())) {
+					// TODO: should we clone?
+					wbRequest.setStartTimestamp(null);
+					wbRequest.setEndTimestamp(null);
+				}
 			}
 			String requestPath = 
 				accessPoint.translateRequestPathQuery(httpRequest);


### PR DESCRIPTION
...when a capture or url query is being performed. Proposed fix for #190.