### PR TITLE
removes duplicate proxy accessPointPath property in wayback.xml

### DIFF
--- a/src/site/xdoc/release_notes.xml
+++ b/src/site/xdoc/release_notes.xml
@@ -23,6 +23,12 @@
           <li>Minor fixes to replace hardcoded port numbers aun URL prefixes with placeholders. <a href="https://github.com/iipc/openwayback/pull/223">#223</a></li>
        </ul>
       </subsection>
+      <subsection name="Bug Fixes">
+       <ul>
+          <li>Removed duplicate accessPointPath property in proxy replay section of wayback.xml <a href="https://github.com/iipc/openwayback/issues/229">#229</a>
+          </li>
+       </ul>
+      </subsection>
     </section>
     <section name="OpenWayback 2.1.0 Release">
       <subsection name="Features">

--- a/wayback-webapp/src/main/webapp/WEB-INF/wayback.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/wayback.xml
@@ -310,7 +310,6 @@
     <property name="bounceToReplayPrefix" value="false" />
     <property name="bounceToQueryPrefix" value="false" />
     <property name="refererAuth" value="" />
-    <property name="accessPointPath" value="8090"/>
 
     <property name="staticPrefix" value="http://localhost:8090/" />
     <property name="replayPrefix" value="http://localhost:8090/" />


### PR DESCRIPTION
Removed duplicate accessPointPath property in proxy replay section of wayback.xml that prevents proper deployment of OpenWayback when the section is uncommented. Addresses <a href="https://github.com/iipc/openwayback/issues/229">#229</a>.