### PR TITLE
Make the tests platform independent.

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -11,6 +11,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 ### Bug fixes
 * Fix for WatchedCDXSourceTest on MaxOSX. [#271] (https://github.com/iipc/openwayback/issues/271)
 * UTF BOM detection is not working at all [#283](https://github.com/iipc/openwayback/issues/283)
+* Failing test on Windows: EmbeddedCDXServerIndexTest.handleRequest() depends on plattform line ending. [#236]
 
 ## OpenWayback 2.2.0 Release
 ### Features

--- a/wayback-core/src/test/java/org/archive/wayback/resourceindex/cdxserver/EmbeddedCDXServerIndexTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/resourceindex/cdxserver/EmbeddedCDXServerIndexTest.java
@@ -517,8 +517,8 @@ public class EmbeddedCDXServerIndexTest extends TestCase {
 		
 		CDXQuery query = (CDXQuery)args[0];
 		assertEquals("API query should not have filter by default", 0, query.getFilter().length);
-		
-		assertEquals(CDXLINE1+"\n", sw.toString());
+
+		assertEquals(String.format("%1$s%n", CDXLINE1), sw.toString());
 	}
 
 	/**


### PR DESCRIPTION
On Windows ``testHandleRequest`` fails due to platform dependent line endings. This is because a String build with a PrintWriter is compared to a String with a hardcoded Unix line ending.

To fix this, I've added a platform dependent line ending to the expected string with ``String.format()``.

This pull request resolves #236.
