### PR TITLE
Added FilenameFilter using regular expressions.

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -7,6 +7,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 ## OpenWayback 2.3.0 Release
 ### Features
 *  Use Markdown for documentation. [#265](https://github.com/iipc/openwayback/issues/265)
+*  New FilenameFilter to include or exclude files using regular expressions [#237](https://github.com/iipc/openwayback/issues/237)
 
 ### Bug fixes
 * Fix for WatchedCDXSourceTest on MaxOSX. [#271] (https://github.com/iipc/openwayback/issues/271)

--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/resourcefile/RegexFilenameFilter.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/resourcefile/RegexFilenameFilter.java
@@ -1,0 +1,56 @@
+package org.archive.wayback.resourcestore.resourcefile;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * FilenameFilter which allows flexible configuration of accepted files. All files matching accepRegex are accepted,
+ * until they match rejectRegex.
+ *
+ * @author mbitzl
+ * @version $Date$, $Revision$
+ */
+public class RegexFilenameFilter implements FilenameFilter {
+    private Pattern accept;
+    private Pattern reject;
+
+    private boolean should(Pattern pattern, String name) {
+        if (pattern == null) {
+            return false;
+        }
+        Matcher matcher = pattern.matcher(name);
+        return matcher.matches();
+    }
+
+    @Override
+    public boolean accept(File dir, String name) {
+        return should(accept, name) && !should(reject, name);
+    }
+
+    public void setAcceptRegex(String acceptRegex) {
+        this.accept = Pattern.compile(acceptRegex);
+    }
+
+    /**
+     * All files with filenames matching this regular expression will be considered to accept.
+     *
+     */
+    public String getAcceptRegex() {
+        return accept.pattern();
+    }
+
+    public void setRejectRegex(String rejectRegex) {
+        this.reject = Pattern.compile(rejectRegex);
+    }
+
+
+    /**
+     * All files with filenames matching this regular expression will be rejected, even if they would match acceptRegex.
+     *
+     */
+    public String getRejectRegex() {
+        return reject.pattern();
+    }
+}

--- a/wayback-core/src/test/java/org/archive/wayback/resourcestore/resourcefile/RegexFilenameFilterTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/resourcestore/resourcefile/RegexFilenameFilterTest.java
@@ -1,0 +1,60 @@
+package org.archive.wayback.resourcestore.resourcefile;
+
+import junit.framework.TestCase;
+
+import java.io.File;
+
+/**
+ * Tests for RegexFilenameFilter.
+ *
+ * @author mbitzl
+ */
+public class RegexFilenameFilterTest extends TestCase {
+
+    private File directory;
+    private RegexFilenameFilter filter;
+
+    public void setUp() {
+        directory = null;
+        filter = new RegexFilenameFilter();
+    }
+
+    public void testAcceptsFileMatchingAcceptRegex() {
+        filter.setAcceptRegex("^.*\\.warc\\.gz");
+        assertTrue(filter.accept(directory, "beautiful.warc.gz"));
+    }
+
+    public void testRejectsFileMatchingAcceptRegex() {
+        filter.setAcceptRegex("^.*\\.warc\\.gz");
+        assertFalse(filter.accept(directory, "beautiful.txt"));
+    }
+
+    public void testRejectsFileWithoutAnyAcceptRegex() {
+        assertFalse(filter.accept(directory, "beautiful.warc.gz"));
+    }
+
+    public void testRejectsFileMatchingRejectRegex() {
+        filter.setAcceptRegex("^.*\\.warc\\.gz");
+        filter.setRejectRegex(".*temp.*");
+        assertFalse(filter.accept(directory, "beautiful.temp.warc.gz"));
+    }
+
+    public void testAcceptsFileNotMatchingRejectRegex() {
+        filter.setAcceptRegex("^.*\\.warc\\.gz");
+        filter.setRejectRegex(".*temp.*");
+        assertTrue(filter.accept(directory, "beautiful.warc.gz"));
+    }
+
+    public void testGetAcceptRegexReturnsRegex() {
+        String regex = "^.*\\.warc\\.gz";
+        filter.setAcceptRegex(regex);
+        assertEquals(regex, filter.getAcceptRegex());
+    }
+
+    public void testGetRejectRegexReturnsRegex() {
+        String regex = "^.*\\.warc\\.gz";
+        filter.setRejectRegex(regex);
+        assertEquals(regex, filter.getRejectRegex());
+    }
+
+}


### PR DESCRIPTION
As described in issue #237, we use OpenWayback for visual control of harvested websites. Unfortunately, the Web Curator Tool creates temporary WARC files in the same directory as the WARC files we want to view. This leads to indexed WARC files we do not want to view (the temporary ones).

Therefore, we created a FileFilter that allows configuration of the included and excluded files using regular expressions:

        <bean class="org.archive.wayback.resourcestore.resourcefile.DirectoryResourceFileSource">
          <property name="name" value="files" />
          <property name="prefix" value="${wayback.archivedir.1}" />
          <property name="recurse" value="true" />
          <property name="filter">
            <bean class="org.archive.wayback.resourcestore.resourcefile.RegexFilenameFilter">
              <property name="acceptRegex" value="^.*(warc\.gz|arc\.gz|warc|arc)$" />
              <property name="rejectRegex" value=".*ver.*" />
            </bean>
          </property>
        </bean>

This example would include all *.warc, *.arc, *.warc.gz and *.arc.gz files, omitting those with a filename containing "ver" (that's how the Web Curator Tool names the temporary files - by adding ver1, ver2,... to the filenames).