### PR TITLE
Fix closestGroup race condition in RemoteResourceIndex

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/resourceindex/RemoteResourceIndex.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourceindex/RemoteResourceIndex.java
@@ -75,8 +75,6 @@ public class RemoteResourceIndex implements ResourceIndex {
 	
 	private DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
-    private ClosestTrackingCaptureFilterGroup closestGroup;
-
 	private static final String WB_XML_REQUEST_TAGNAME = "request";
 
 
@@ -127,9 +125,9 @@ public class RemoteResourceIndex implements ResourceIndex {
 		ResourceNotInArchiveException, BadQueryException,
 		AccessControlException {
 //		throw new ResourceIndexNotAvailableException("oops");
-        closestGroup = new ClosestTrackingCaptureFilterGroup(wbRequest, canonicalizer);
+		ClosestTrackingCaptureFilterGroup closestGroup = new ClosestTrackingCaptureFilterGroup(wbRequest, canonicalizer);
 		SearchResults results = urlToSearchResults(getRequestUrl(wbRequest),
-				getSearchResultFilters(wbRequest));
+				getSearchResultFilters(wbRequest, closestGroup));
         closestGroup.annotateResults(results);
         return results;
 	}
@@ -206,7 +204,7 @@ public class RemoteResourceIndex implements ResourceIndex {
 	}
 	
 	protected ObjectFilter<CaptureSearchResult> getSearchResultFilters(
-			WaybackRequest wbRequest) {
+			WaybackRequest wbRequest, ClosestTrackingCaptureFilterGroup closestGroup) {
 		ObjectFilterChain<CaptureSearchResult> filters = null;
 		if (wbRequest.isReplayRequest()) {
 			filters = new ObjectFilterChain<CaptureSearchResult>();


### PR DESCRIPTION
Pull request #194 introduced a closestGroup field in RemoteResourceIndex. However the group object is request-specific and so the values should not be shared between multiple threads.  The resulting race condition frequently causes intermittent 404 errors preventing resources from loading with this message logged:

    Apr 19, 2015 10:52:03 PM org.archive.wayback.webapp.AccessPoint handleReplay
    WARNING: (1)LOADFAIL: Self-Redirect: No Closest Match Found /20140309082106/http://catalogue.nla.gov.au/js/barcode.js?1225315091
    Apr 19, 2015 10:52:03 PM org.archive.wayback.webapp.AccessPoint logError
    WARNING: Runtime Error org.archive.wayback.exception.ResourceNotAvailableException: Self-Redirect: No Closest Match Found

This change replaces the closestGroup field with a local variable thus ensuring it cannot be overwritten by other threads.
