### PR TITLE
Issue217 dymamic config params

### DIFF
--- a/src/site/xdoc/release_notes.xml
+++ b/src/site/xdoc/release_notes.xml
@@ -22,6 +22,7 @@
           <li>WatchedCDXSource now monitors directories for new CDX files. <a href="https://github.com/iipc/openwayback/pull/181">#181</a></li>
           <li>Minor fixes to replace hardcoded port numbers aun URL prefixes with placeholders. <a href="https://github.com/iipc/openwayback/pull/223">#223</a></li>
           <li>Require Java 7.<a href="https://github.com/iipc/openwayback/pull/178">#178</a></li>
+          <li>Environment variables for config options.<a href="https://github.com/iipc/openwayback/pull/217">#217</a></li>
        </ul>
       </subsection>
       <subsection name="Bug Fixes">

--- a/wayback-webapp/src/main/webapp/WEB-INF/wayback.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/wayback.xml
@@ -11,21 +11,28 @@
 		                 locationdb storage.
 -->
 
-  <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-    <property name="properties">
-      <value>
-        wayback.basedir=/tmp/openwayback
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="properties">
+            <value>
+          
+                <!-- Customize these basic placeholders. -->
+                WAYBACK_BASEDIR=/tmp/openwayback
+                WAYBACK_URL_SCHEME=http
+                WAYBACK_URL_HOST=localhost
+                WAYBACK_URL_PORT=8080
+                
+                <!-- Environment variable overrides (only if present). No need to customize these. -->
+                wayback.basedir=#{ systemEnvironment['WAYBACK_BASEDIR'] ?: '${WAYBACK_BASEDIR}' }
+                wayback.url.scheme=#{ systemEnvironment['WAYBACK_URL_SCHEME'] ?: '${WAYBACK_URL_SCHEME}' }
+                wayback.url.host=#{ systemEnvironment['WAYBACK_URL_HOST'] ?: '${WAYBACK_URL_HOST}' }
+                wayback.url.port=#{ systemEnvironment['WAYBACK_URL_PORT'] ?: '${WAYBACK_URL_PORT}' }
         
-        wayback.archivedir.1=${wayback.basedir}/files1/
-        wayback.archivedir.2=${wayback.basedir}/files2/
-        
-        wayback.url.scheme=http
-        wayback.url.host=localhost
-        wayback.url.port=8080
-        wayback.url.prefix=${wayback.url.scheme}://${wayback.url.host}:${wayback.url.port}
-      </value>
-    </property>
-  </bean>
+                wayback.archivedir.1=${wayback.basedir}/files1/
+                wayback.archivedir.2=${wayback.basedir}/files2/
+                wayback.url.prefix=${wayback.url.scheme}://${wayback.url.host}:${wayback.url.port}
+            </value>
+        </property>
+    </bean>
 
   <bean id="waybackCanonicalizer" class="org.archive.wayback.util.url.AggressiveUrlCanonicalizer" />
 


### PR DESCRIPTION
The four parameters "wayback.basedir", "wayback.url.scheme", "wayback.url.host" and "wayback.url.port" defined inside wayback.xml are now configurable at startup using environment variables.

The code is only tested on UNIX, using:
export WAYBACK_BASEDIR
export WAYBACK_URL_SCHEME
export WAYBACK_URL_HOST
export WAYBACK_URL_PORT
either from the command line or inside a startup script, but it should also function under Windows using
"set ENV_VAR_NAME=value"