### PR TITLE
Add range request handling to TransparentReplayRenderer.

### DIFF
--- a/src/site/xdoc/release_notes.xml
+++ b/src/site/xdoc/release_notes.xml
@@ -27,6 +27,7 @@
           <li>WatchedCDXSource now optionally recurses and filters on filenames. <a href="https://github.com/iipc/openwayback/pull/219">#219</a></li>
           <li>Support for Internationalized Domain Name (IDN) <a href="https://github.com/iipc/openwayback/pull/27">#27</a></li>
           <li>UI localization.<a href="https://github.com/iipc/openwayback/pull/46">#46</a></li>
+	  <li>TransparentReplayRenderer now has limited support for Range requests. <a href="https://github.com/iipc/openwayback/issues/179">#179</a></li>
        </ul>
       </subsection>
       <subsection name="Bug Fixes">

--- a/wayback-core/src/main/java/org/archive/wayback/exception/RangeNotSatisfiable.java
+++ b/wayback-core/src/main/java/org/archive/wayback/exception/RangeNotSatisfiable.java
@@ -1,0 +1,38 @@
+package org.archive.wayback.exception;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.archive.wayback.core.Resource;
+
+/**
+ * RangeNotSatisfiable is thrown when selected Resource does not have content data
+ * that can satisfy requested range.
+ * This happens when the Resource itself is a capture of range request that does not cover
+ * requested range.
+ * @see org.archive.wayback.replay.TransparentReplayRenderer
+ */
+public class RangeNotSatisfiable extends SpecificCaptureReplayException {
+	private static final long serialVersionUID = 1L;
+
+	private Resource origResource;
+	private long[][] requestedRanges;
+
+	public RangeNotSatisfiable(Resource origResource, long[][] requestedRanges, String message) {
+		super(message, "RangeNotSatisfiable");
+		this.origResource = origResource;
+		this.requestedRanges = requestedRanges;
+	}
+
+	@Override
+	public int getStatus() {
+		return HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE;
+	}
+
+	public Resource getOrigResource() {
+		return origResource;
+	}
+
+	public long[][] getRequestedRanges() {
+		return requestedRanges;
+	}
+}

--- a/wayback-core/src/main/java/org/archive/wayback/replay/RangeResource.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/RangeResource.java
@@ -1,0 +1,199 @@
+/*
+ *  This file is part of the Wayback archival access software
+ *   (http://archive-access.sourceforge.net/projects/wayback/).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.archive.wayback.replay;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.archive.wayback.core.Resource;
+import org.archive.wayback.exception.RangeNotSatisfiable;
+
+import com.google.common.io.ByteStreams;
+
+/**
+ * RangeResource decorates Resource to render partial content response
+ * to range request.
+ *
+ * After constructing with wrapped Resource and requested range,
+ * call {@link #parseRange()} to prepare internal state for rendering.
+ * The method will throw {@link RangeNotSatisfiable} if the requested
+ * byte ranges cannot be replayed with the base Resource.
+ *
+ * RangeResource currently only works with:
+ * <ul>
+ * <li>A single-range request
+ * <li>A 200 capture with {@code Content-Length}, or a valid 206 capture
+ * with single range (i.e. no support for {@code multipart/byteranges})
+ * </ul>
+ * @see HttpHeaderOperation#parseRanges(String)
+ */
+public class RangeResource extends Resource {
+	private Resource origResource;
+	private long[][] requestedRanges;
+	private long outputLength;
+	private Map<String, String> httpHeaders;
+
+	/**
+	 * Initialize with base Resource and requested ranges.
+	 * @param origResource base resource
+	 * @param requestedRanges requested range
+	 * @see HttpHeaderOperation#parseRanges(String)
+	 */
+	public RangeResource(Resource origResource, long[][] requestedRanges) {
+		this.origResource = origResource;
+		this.requestedRanges = requestedRanges;
+	}
+
+	/**
+	 * Prepare response for requested range.
+	 * @throws RangeNotSatisfiable base Resource either does not have
+	 * enough data to fulfill the request, or have invalid header field.
+	 */
+	public void parseRange() throws RangeNotSatisfiable, IOException {
+		if (requestedRanges.length > 1) {
+			throw new RangeNotSatisfiable(origResource, requestedRanges,
+				"Multiple ranges are not supported yet");
+		}
+		final long[] firstRange = requestedRanges[0];
+		long start = firstRange[0];
+		long stop = firstRange[1];
+
+		long[] availRange = availableRange();
+		if (availRange == null) {
+			throw new RangeNotSatisfiable(origResource, requestedRanges,
+				"available range cannot be determined");
+		}
+		if (start < 0) {
+			// tail range (-N) - translate to absolute positions
+			start = availRange[2] + start;
+			stop = availRange[2];
+		}
+		if (stop < 0) {
+			// M-
+			stop = availRange[2];
+		}
+		if (start < availRange[0] || stop > availRange[1]) {
+			// requested range is not satisfiable with content available
+			// in the resource.
+			// TODO: if availRange[1] == file length, stop > availRange[1]
+			// is okay. We just replay start..availRange[1]. Guessing it
+			// must be extremely rare to have such capture.
+			throw new RangeNotSatisfiable(origResource, requestedRanges,
+				"requested range is not available in this capture");
+		}
+		if (start > availRange[0]) {
+			origResource.skip(start - availRange[0]);
+		}
+		outputLength = stop - start;
+		setInputStream(ByteStreams.limit(origResource, outputLength));
+
+		httpHeaders = new HashMap<String, String>();
+		httpHeaders.putAll(origResource.getHttpHeaders());
+		// TODO: Add Content-Range
+		String contentRange = String.format("bytes %d-%d/%d", start,
+			stop - 1, availRange[2]);
+		HttpHeaderOperation.replaceHeader(httpHeaders,
+			HttpHeaderOperation.HTTP_CONTENT_RANGE_HEADER, contentRange);
+		HttpHeaderOperation
+			.replaceHeader(httpHeaders, HttpHeaderOperation.HTTP_LENGTH_HEADER,
+				Long.toString(stop - start));
+	}
+
+	/**
+	 * Look at resource HTTP header fields and determine the byte range available.
+	 * @return array with three long values:
+	 * <ol>
+	 * <li><em>offset of first available byte</em>,
+	 * <li><em>offset of last available byte</em> + 1,
+	 * <li><em>instance-length</em>
+	 * </ol>
+	 * Note this method returns {@code null} for {@code multipart/byteranges}
+	 * response.
+	 */
+	protected long[] availableRange() {
+		// for revisit capture, HTTP headers comes from revisiting resource.
+		// it should be okay to assume revisited resource has exactly the same
+		// Content-Range header field.
+		Map<String, String> respHeaders = origResource.getHttpHeaders();
+		long[] contentRange = HttpHeaderOperation
+			.getContentRange(respHeaders);
+		long availStart, availStop, contentLength;
+		if (contentRange == null) {
+			// regular 200 response (or Content-Range is invalid)
+			String clen = HttpHeaderOperation.getContentLength(respHeaders);
+			if (clen != null) {
+				try {
+					contentLength = Long.parseLong(clen);
+				} catch (NumberFormatException ex) {
+					return null;
+				}
+			} else {
+				// no Content-Length - probably chunked encoded -
+				// not supported yet (TODO: determine length by
+				// actually reading?)
+				return null;
+			}
+			availStart = 0;
+			availStop = contentLength;
+		} else {
+			// 206, or perhaps 416 response
+			if (contentRange[0] < 0) {
+				// 416 (both [0] and [1] are -1 for */instance-length)
+				return null;
+			}
+			availStart = contentRange[0];
+			availStop = contentRange[1];
+			contentLength = contentRange[2];
+			// TODO: need support for M-N/*?
+			if (contentLength < 0)
+				return null;
+			// sanity check
+			if (availStop <= availStart) return null;
+			if (contentLength < availStop) return null;
+		}
+		return new long[] { availStart, availStop, contentLength };
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (origResource != null) {
+			origResource.close();
+			origResource = null;
+		}
+	}
+
+	@Override
+	public Map<String, String> getHttpHeaders() {
+		return httpHeaders;
+	}
+
+	@Override
+	public long getRecordLength() {
+		return origResource.getRecordLength();
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpServletResponse.SC_PARTIAL_CONTENT;
+	}
+}

--- a/wayback-core/src/main/java/org/archive/wayback/replay/TransparentReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/TransparentReplayRenderer.java
@@ -33,12 +33,21 @@ import org.archive.wayback.core.CaptureSearchResult;
 import org.archive.wayback.core.CaptureSearchResults;
 import org.archive.wayback.core.Resource;
 import org.archive.wayback.core.WaybackRequest;
-import org.archive.wayback.exception.BadContentException;
+import org.archive.wayback.exception.SpecificCaptureReplayException;
 
 /**
  * ReplayRenderer implementation which returns the archive document as 
  * pristinely as possible -- no modifications to response code, HTTP headers,
  * or original byte-stream.
+ *
+ * <p>
+ * Now this class has a limited support for range requests. If the request
+ * has {@code Range} header, it tries to fulfill it by extracting requested
+ * byte range from the archived content (either 200 or 206 responses).
+ * If the Resource is not suitable for replaying the request ranges,
+ * {@code renderResource} throws {@link RangeNotSatisfiable}, so that
+ * replay process can try another capture, or take other actions.
+ * </p>
  *
  * @author brad
  * @version $Date$, $Revision$
@@ -63,31 +72,28 @@ public class TransparentReplayRenderer implements ReplayRenderer {
 			HttpServletResponse httpResponse, WaybackRequest wbRequest,
 			CaptureSearchResult result, Resource resource,
 			ResultURIConverter uriConverter, CaptureSearchResults results)
-					throws ServletException, IOException, BadContentException {
-		renderResource(httpRequest, httpResponse, wbRequest, result, resource,
-				resource, uriConverter, results);
-	}
+			throws ServletException, IOException,
+			SpecificCaptureReplayException {
+		String rangeHeader = httpRequest.getHeader(HttpHeaderOperation.HTTP_RANGE_HEADER_UP);
+		if (rangeHeader != null) {
+			long[][] ranges = HttpHeaderOperation.parseRanges(rangeHeader);
+			@SuppressWarnings("resource")
+			RangeResource rangeResource = new RangeResource(resource,
+				ranges);
+			rangeResource.parseRange();
+			resource = rangeResource;
+		}
 
-	@Override
-	public void renderResource(HttpServletRequest httpRequest,
-			HttpServletResponse httpResponse, WaybackRequest wbRequest,
-			CaptureSearchResult result, Resource httpHeadersResource,
-			Resource payloadResource, ResultURIConverter uriConverter,
-			CaptureSearchResults results) throws ServletException, IOException,
-			BadContentException {
+		HttpHeaderOperation.copyHTTPMessageHeader(resource, httpResponse);
 
-		HttpHeaderOperation.copyHTTPMessageHeader(httpHeadersResource, httpResponse);
+		// Note: httpHeaderProcessor may remove Content-Length.
+		Map<String, String> headers = HttpHeaderOperation.processHeaders(
+			resource, result, uriConverter, httpHeaderProcessor);
 
-		Map<String,String> headers = HttpHeaderOperation.processHeaders(
-				httpHeadersResource, result, uriConverter, httpHeaderProcessor);
+		String origLength = HttpHeaderOperation.getContentLength(resource.getHttpHeaders());
+		if (origLength != null) {
+			HttpHeaderOperation.replaceHeader(headers, HttpHeaderOperation.HTTP_LENGTH_HEADER, origLength);
 
-		// HACKHACK: getContentLength() may not find the original content length
-		// if a HttpHeaderProcessor has mangled it too badly. Should this
-		// happen in the HttpHeaderProcessor itself?
-		String origLength = HttpHeaderOperation.getContentLength(headers);
-		if(origLength != null) {
-			headers.put(HttpHeaderOperation.HTTP_LENGTH_HEADER, origLength);
-			
 			long contentLength = -1;
 			
 			try {
@@ -108,15 +114,30 @@ public class TransparentReplayRenderer implements ReplayRenderer {
 		OutputStream os = httpResponse.getOutputStream();
 		byte[] buffer = new byte[BUFFER_SIZE];
 		long total = 0;
-		for (int r = -1; (r = payloadResource.read(buffer, 0, BUFFER_SIZE)) != -1;) {
+		for (int r = -1; (r = resource.read(buffer, 0, BUFFER_SIZE)) != -1;) {
 			os.write(buffer, 0, r);
 			total += r;
 		}
-		if(total == 0) {
-			if(headers.size() == 0) {
+		if (total == 0) {
+			if (headers.size() == 0) {
 				// totally empty response
 				httpResponse.setContentLength(0);
 			}
 		}
+	}
+
+	@Override
+	public void renderResource(HttpServletRequest httpRequest,
+			HttpServletResponse httpResponse, WaybackRequest wbRequest,
+			CaptureSearchResult result, Resource httpHeadersResource,
+			Resource payloadResource, ResultURIConverter uriConverter,
+			CaptureSearchResults results) throws ServletException, IOException,
+			SpecificCaptureReplayException {
+		if (httpHeadersResource != payloadResource) {
+			httpHeadersResource = new CompositeResource(
+				httpHeadersResource, payloadResource);
+		}
+		renderResource(httpRequest, httpResponse, wbRequest, result,
+			httpHeadersResource, uriConverter, results);
 	}
 }

--- a/wayback-core/src/test/java/org/archive/wayback/replay/HttpHeaderOperationTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/HttpHeaderOperationTest.java
@@ -1,0 +1,186 @@
+/*
+ *  This file is part of the Wayback archival access software
+ *   (http://archive-access.sourceforge.net/projects/wayback/).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.wayback.replay;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import junit.framework.TestCase;
+
+/**
+ * Test for {@link HttpHeaderOperation}
+ */
+public class HttpHeaderOperationTest extends TestCase {
+
+	protected String toString(long[] a) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("[");
+		for (int i = 0; i < a.length; i++) {
+			if (i > 0) sb.append(", ");
+			sb.append(a[i]);
+		}
+		sb.append("]");
+		return sb.toString();
+	}
+
+	protected boolean equals(long[] a, long[] b) {
+		if (a.length != b.length) return false;
+		for (int i = 0; i < a.length; i++) {
+			if (a[i] != b[i]) return false;
+		}
+		return true;
+	}
+
+	protected void assertEquals(String message, long[] expected, long[] actual) {
+		if (!equals(expected, actual)) {
+			fail(message + " expected " + toString(expected) + ", got " + toString(actual));
+		}
+	}
+
+	protected void assertEquals(long[][] expected, long[][] actual) {
+		for (int n = 0; ; n++) {
+			if (n >= expected.length && n >= actual.length)
+				break;
+			if (n >= expected.length)
+				fail("actual has more elements than expected");
+			if (n >= actual.length)
+				fail("actual has less elements than expected");
+			assertEquals("element " + n, expected[n], actual[n]);
+		}
+	}
+
+	public void testGetRange() throws Exception {
+		Map<String, String> headers = new HashMap<String, String>();
+
+		long[][] r = HttpHeaderOperation.getRange(headers);
+		assertNull(r);
+
+		headers.put("Range", "bytes=0-499");
+		r = HttpHeaderOperation.getRange(headers);
+		assertEquals(new long[][] { { 0, 500 } }, r);
+
+		headers.put("Range", "bytes=500-999");
+		r = HttpHeaderOperation.getRange(headers);
+		assertEquals(new long[][] { { 500, 1000 } }, r);
+
+		headers.put("Range", "bytes=0-0");
+		r = HttpHeaderOperation.getRange(headers);
+		assertEquals(new long[][] { { 0, 1 } }, r);
+		headers.put("Range", "bytes=0-");
+		r = HttpHeaderOperation.getRange(headers);
+		assertEquals(new long[][] { { 0, -1 } }, r);
+
+		headers.put("Range", "bytes=-500");
+		r = HttpHeaderOperation.getRange(headers);
+		assertEquals(new long[][] { { -500, -1 } }, r);
+
+		headers.put("Range", "bytes=0-499,500-999");
+		r = HttpHeaderOperation.getRange(headers);
+		assertEquals(new long[][] { { 0, 500 }, { 500, 1000 } }, r);
+
+		headers.put("Range", "bytes=0-0,-1");
+		r = HttpHeaderOperation.getRange(headers);
+		assertEquals(new long[][] { { 0, 1 }, { -1, -1 } }, r);
+	}
+
+	public void testGetRange_pathological() throws Exception {
+		Map<String, String> headers = new HashMap<String, String>();
+
+		long[][] r;
+		headers.put("Range", "bytes=100");
+		r = HttpHeaderOperation.getRange(headers);
+		assertNull(r);
+
+		headers.put("Range", "bytes=300-100");
+		r = HttpHeaderOperation.getRange(headers);
+		assertNull(r);
+
+		headers.put("Range", "bytes=-0");
+		r = HttpHeaderOperation.getRange(headers);
+		assertNull(r);
+
+		headers.put("Range", "bytes=-");
+		r = HttpHeaderOperation.getRange(headers);
+		assertNull(r);
+
+		headers.put("Range", "bytes=--100-");
+		r = HttpHeaderOperation.getRange(headers);
+		assertNull(r);
+
+		headers.put("Range", "bytes=");
+		r = HttpHeaderOperation.getRange(headers);
+		assertNull(r);
+
+		headers.put("Range", "bytes=0-ab");
+		r = HttpHeaderOperation.getRange(headers);
+		assertNull(r);
+
+		headers.put("Range",  "100-200");
+		r = HttpHeaderOperation.getRange(headers);
+		assertNull(r);
+	}
+
+	public void testGetContentRange() throws Exception {
+		Map<String, String> headers = new HashMap<String, String>();
+
+		long[] r = HttpHeaderOperation.getContentRange(headers);
+		assertNull(r);
+
+		headers.put("Content-Range", "bytes 0-499/5000");
+		r = HttpHeaderOperation.getContentRange(headers);
+		assertEquals("getContentRange", new long[] { 0, 500, 5000 }, r);
+
+		headers.put("Content-Range", "bytes */5000");
+		r = HttpHeaderOperation.getContentRange(headers);
+		assertEquals("getContentRange", new long[] { -1, -1, 5000 }, r);
+
+		headers.put("Content-Range", "bytes 0-499/*");
+		r = HttpHeaderOperation.getContentRange(headers);
+		assertEquals("getContentRange", new long[] { 0, 500, -1 }, r);
+
+		headers.put("Content-Range", "bytes 499-499/5000");
+		r = HttpHeaderOperation.getContentRange(headers);
+		assertEquals("getContentRange", new long[] { 499, 500, 5000 }, r);
+
+		// ok to have multiple spaces
+		headers.put("Content-Range", "bytes     0-499/5000");
+		r = HttpHeaderOperation.getContentRange(headers);
+		assertEquals("getContentRange", new long[] { 0, 500, 5000 }, r);
+	}
+
+	public void testGetContentRange_pathological() throws Exception {
+		Map<String, String> headers = new HashMap<String, String>();
+
+		long[] r;
+
+		headers.put("Content-Range", "bytes -499/5000");
+		r = HttpHeaderOperation.getContentRange(headers);
+		assertNull(r);
+
+		headers.put("Content-Range", "bytes 499-/5000");
+		r = HttpHeaderOperation.getContentRange(headers);
+		assertNull(r);
+
+		headers.put("Content-Range", "bytes300-299/5000");
+		r = HttpHeaderOperation.getContentRange(headers);
+		assertNull(r);
+	}
+}

--- a/wayback-core/src/test/java/org/archive/wayback/replay/TransparentReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/TransparentReplayRendererTest.java
@@ -7,7 +7,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 
@@ -40,8 +42,7 @@ import org.easymock.EasyMock;
 public class TransparentReplayRendererTest extends TestCase {
 
     TransparentReplayRenderer cut;
-    // never used in TransparentReplayRenerer.
-    HttpServletRequest request = null;
+    HttpServletRequest request;
     HttpServletResponse response;
     WaybackRequest wbRequest;
     CaptureSearchResult result = new CaptureSearchResult();
@@ -64,6 +65,7 @@ public class TransparentReplayRendererTest extends TestCase {
         // result is only used in HttpHeaderOperation.processHeaders()
         results = new CaptureSearchResults();
         
+        request = EasyMock.createNiceMock(HttpServletRequest.class);
         response = EasyMock.createMock(HttpServletResponse.class);
     }
 
@@ -253,5 +255,239 @@ public class TransparentReplayRendererTest extends TestCase {
         // content is the original gzip-compressed bytes for PAYLOAD_GIF.
         String output = new String(servletOutput.getBytes(), "UTF-8");
         assertEquals(payload, output);
+    }
+
+	protected byte[] buildTestBytes(int length) {
+		byte[] bytes = new byte[length];
+		for (int i = 0; i < length; i++) {
+			bytes[i] = (byte)(i & 0xff);
+		}
+		return bytes;
+	}
+
+    public void testRenderResource_Range_From200() throws Exception {
+		final String ct = "application/octet-stream";
+		final byte[] payload = buildTestBytes(1024);
+		final byte[] recordBytes = TestWARCRecordInfo.buildHttpResponseBlock(
+			"200 OK", ct, payload, false);
+		WARCRecordInfo recinfo = new TestWARCRecordInfo(recordBytes);
+		TestWARCReader ar = new TestWARCReader(recinfo);
+		WARCRecord rec = ar.get(0);
+		Resource payloadResource = new WarcResource(rec, ar);
+		payloadResource.parseHeaders();
+
+		final String range = "bytes=10-19";
+		// range request
+		EasyMock.expect(request.getHeader(EasyMock.matches("(?i)range$")))
+			.andStubReturn(range);
+
+		TestServletOutputStream servletOutput = new TestServletOutputStream();
+		// expectations
+		response.setStatus(206);
+		EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
+		Capture<String> contentRange = new Capture<String>(CaptureType.FIRST);
+		response.setHeader(EasyMock.matches("(?i)content-range$"),
+			EasyMock.capture(contentRange));
+		EasyMock.expectLastCall().once();
+		Capture<String> contentLength = new Capture<String>(CaptureType.FIRST);
+		response.setHeader(EasyMock.matches("(?i)content-length$"),
+			EasyMock.capture(contentLength));
+		EasyMock.expectLastCall().once();
+		response.setHeader(EasyMock.<String>anyObject(),
+			EasyMock.<String>anyObject());
+		EasyMock.expectLastCall().anyTimes();
+
+		EasyMock.replay(request, response, uriConverter);
+
+		cut.renderResource(request, response, wbRequest, result,
+			payloadResource, uriConverter, results);
+
+		EasyMock.verify(response);
+
+		assertTrue(contentRange.hasCaptured());
+		String contentRangeValue = contentRange.getValue();
+		assertEquals("bytes 10-19/1024", contentRangeValue);
+
+		assertTrue(contentLength.hasCaptured());
+		assertEquals("10", contentLength.getValue());
+
+		byte[] outputBytes = servletOutput.getBytes();
+		assertEquals(10, outputBytes.length);
+		assertEquals(10, outputBytes[0]);
+		assertEquals(19, outputBytes[9]);
+    }
+
+    public void testRenderResource_Range_From200_All() throws Exception {
+		final String ct = "application/octet-stream";
+		final byte[] payload = buildTestBytes(1024);
+		final byte[] recordBytes = TestWARCRecordInfo.buildHttpResponseBlock(
+			"200 OK", ct, payload, false);
+		WARCRecordInfo recinfo = new TestWARCRecordInfo(recordBytes);
+		TestWARCReader ar = new TestWARCReader(recinfo);
+		WARCRecord rec = ar.get(0);
+		Resource payloadResource = new WarcResource(rec, ar);
+		payloadResource.parseHeaders();
+
+		final String range = "bytes=0-";
+		// range request
+		EasyMock.expect(request.getHeader(EasyMock.matches("(?i)range$")))
+			.andStubReturn(range);
+
+		TestServletOutputStream servletOutput = new TestServletOutputStream();
+		// expectations
+		response.setStatus(206);
+		EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
+		Capture<String> contentRange = new Capture<String>(CaptureType.FIRST);
+		response.setHeader(EasyMock.matches("(?i)content-range$"),
+			EasyMock.capture(contentRange));
+		EasyMock.expectLastCall().once();
+		Capture<String> contentLength = new Capture<String>(CaptureType.FIRST);
+		response.setHeader(EasyMock.matches("(?i)content-length$"),
+			EasyMock.capture(contentLength));
+		EasyMock.expectLastCall().once();
+		response.setHeader(EasyMock.<String>anyObject(),
+			EasyMock.<String>anyObject());
+		EasyMock.expectLastCall().anyTimes();
+
+		EasyMock.replay(request, response, uriConverter);
+
+		cut.renderResource(request, response, wbRequest, result,
+			payloadResource, uriConverter, results);
+
+		EasyMock.verify(response);
+
+		assertTrue(contentRange.hasCaptured());
+		String contentRangeValue = contentRange.getValue();
+		assertEquals("bytes 0-1023/1024", contentRangeValue);
+
+		assertTrue(contentLength.hasCaptured());
+		assertEquals("1024", contentLength.getValue());
+
+		byte[] outputBytes = servletOutput.getBytes();
+		assertEquals(1024, outputBytes.length);
+		assertEquals(0, outputBytes[0]);
+		assertEquals(-1, outputBytes[1023]);
+    }
+
+    public void testRenderResource_Range_From200_Tail() throws Exception {
+		final String ct = "application/octet-stream";
+		final byte[] payload = buildTestBytes(1024);
+		final byte[] recordBytes = TestWARCRecordInfo.buildHttpResponseBlock(
+			"200 OK", ct, payload, false);
+		WARCRecordInfo recinfo = new TestWARCRecordInfo(recordBytes);
+		TestWARCReader ar = new TestWARCReader(recinfo);
+		WARCRecord rec = ar.get(0);
+		Resource payloadResource = new WarcResource(rec, ar);
+		payloadResource.parseHeaders();
+
+		final String range = "bytes=-10";
+		// range request
+		EasyMock.expect(request.getHeader(EasyMock.matches("(?i)range$")))
+			.andStubReturn(range);
+
+		TestServletOutputStream servletOutput = new TestServletOutputStream();
+		// expectations
+		response.setStatus(206);
+		EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
+		Capture<String> contentRange = new Capture<String>(CaptureType.FIRST);
+		response.setHeader(EasyMock.matches("(?i)content-range$"),
+			EasyMock.capture(contentRange));
+		EasyMock.expectLastCall().once();
+		Capture<String> contentLength = new Capture<String>(CaptureType.FIRST);
+		response.setHeader(EasyMock.matches("(?i)content-length$"),
+			EasyMock.capture(contentLength));
+		EasyMock.expectLastCall().once();
+		response.setHeader(EasyMock.<String>anyObject(),
+			EasyMock.<String>anyObject());
+		EasyMock.expectLastCall().anyTimes();
+
+		EasyMock.replay(request, response, uriConverter);
+
+		cut.renderResource(request, response, wbRequest, result,
+			payloadResource, uriConverter, results);
+
+		EasyMock.verify(response);
+
+		assertTrue(contentRange.hasCaptured());
+		String contentRangeValue = contentRange.getValue();
+		assertEquals("bytes 1014-1023/1024", contentRangeValue);
+
+		assertTrue(contentLength.hasCaptured());
+		assertEquals("10", contentLength.getValue());
+
+		byte[] outputBytes = servletOutput.getBytes();
+		assertEquals(10, outputBytes.length);
+		assertEquals(-10, outputBytes[0]);
+		assertEquals(-1, outputBytes[9]);
+    }
+
+	protected static byte[] buildPartialContentResponseBlock(String ctype,
+			byte[] payloadBytes, long startPos, long instanceSize)
+			throws IOException {
+		assertTrue(startPos + payloadBytes.length <= instanceSize);
+		final String CRLF = "\r\n";
+		final String contentRange = String.format("bytes %d-%d/%d", startPos, startPos + payloadBytes.length - 1, instanceSize);
+		ByteArrayOutputStream blockbuf = new ByteArrayOutputStream();
+		Writer bw = new OutputStreamWriter(blockbuf);
+		bw.write("HTTP/1.0 206 Partial Content" + CRLF);
+		bw.write("Content-Type: " + ctype + CRLF);
+		bw.write("Content-Range: " + contentRange + CRLF);
+		bw.write("Content-Length: " + payloadBytes.length + CRLF);
+		bw.write(CRLF);
+		bw.close();
+		blockbuf.write(payloadBytes);
+		return blockbuf.toByteArray();
+    }
+
+    public void testRenderResource_Range_From206() throws Exception {
+		final String ct = "application/octet-stream";
+		final byte[] payload = buildTestBytes(1024);
+		final byte[] recordBytes = buildPartialContentResponseBlock(ct,
+			payload, 10, 1040);
+		WARCRecordInfo recinfo = new TestWARCRecordInfo(recordBytes);
+		TestWARCReader ar = new TestWARCReader(recinfo);
+		WARCRecord rec = ar.get(0);
+		Resource payloadResource = new WarcResource(rec, ar);
+		payloadResource.parseHeaders();
+
+		final String range = "bytes=12-1032";
+		// range request
+		EasyMock.expect(request.getHeader(EasyMock.matches("(?i)range$")))
+			.andStubReturn(range);
+
+		TestServletOutputStream servletOutput = new TestServletOutputStream();
+		// expectations
+		response.setStatus(206);
+		EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
+		Capture<String> contentRange = new Capture<String>(CaptureType.FIRST);
+		response.setHeader(EasyMock.matches("(?i)content-range$"),
+			EasyMock.capture(contentRange));
+		EasyMock.expectLastCall().once();
+		Capture<String> contentLength = new Capture<String>(CaptureType.FIRST);
+		response.setHeader(EasyMock.matches("(?i)content-length$"),
+			EasyMock.capture(contentLength));
+		EasyMock.expectLastCall().once();
+		response.setHeader(EasyMock.<String>anyObject(),
+			EasyMock.<String>anyObject());
+		EasyMock.expectLastCall().anyTimes();
+
+		EasyMock.replay(request, response, uriConverter);
+
+		cut.renderResource(request, response, wbRequest, result,
+			payloadResource, uriConverter, results);
+
+		EasyMock.verify(response);
+
+		assertTrue(contentRange.hasCaptured());
+		String contentRangeValue = contentRange.getValue();
+		assertEquals("bytes 12-1032/1040", contentRangeValue);
+
+		assertTrue(contentLength.hasCaptured());
+		assertEquals("1021", contentLength.getValue());
+
+		byte[] outputBytes = servletOutput.getBytes();
+		assertEquals(1021, outputBytes.length);
+		assertEquals(2, outputBytes[0]);
+		assertEquals(-2, outputBytes[1020]);
     }
 }


### PR DESCRIPTION
(Limitations; it does not support multi-range requests, and capture must
have either Content-Length or instance-length in Content-Range)

iipc/openwayback#179, also internetarchive/wayback#78