### PR TITLE
Fixes WatchedCDXSourceTest on Macs

### DIFF
--- a/src/site/xdoc/release_notes.xml
+++ b/src/site/xdoc/release_notes.xml
@@ -16,6 +16,13 @@
         Full listing of changes and bug fixes are not available prior to release 1.2.0 and between release 1.6.0 and OpeWayback 2.0.0 BETA 1 release. 
       </p>
     </section>
+    <section name="OpenWayback 2.3.0 Release">
+      <subsection name="Bug Fixes">
+       <ul>
+          <li>Fix for WatchedCDXSourceTest on MaxOSX. <a href="https://github.com/iipc/openwayback/pull/271">#271</a></li>
+       </ul>
+      </subsection>
+    </section>
     <section name="OpenWayback 2.2.0 Release">
       <subsection name="Features">
        <ul>

--- a/wayback-core/src/main/java/org/archive/wayback/resourceindex/WatchedCDXSource.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourceindex/WatchedCDXSource.java
@@ -2,6 +2,7 @@ package org.archive.wayback.resourceindex;
 
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static com.sun.nio.file.SensitivityWatchEventModifier.HIGH;
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.FileVisitResult.SKIP_SUBTREE;
 
@@ -223,12 +224,12 @@ public class WatchedCDXSource extends CompositeSearchResultSource {
                 return CONTINUE;
             }
 
-            @Override
+            @SuppressWarnings("restriction")
+			@Override
             public FileVisitResult preVisitDirectory(Path dir,
                     BasicFileAttributes attrs) throws IOException {
                 if (keys.keySet().size() < depth) {
-                    WatchKey key = dir.register(watcher, ENTRY_CREATE,
-                            ENTRY_DELETE);
+                    WatchKey key = dir.register(watcher, new WatchEvent.Kind[]{ENTRY_CREATE, ENTRY_DELETE}, HIGH);
                     LOGGER.info("Watching: " + dir.toString());
                     keys.put(key, dir);
                     return CONTINUE;

--- a/wayback-core/src/test/java/org/archive/wayback/resourceindex/WatchedCDXSourceTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/resourceindex/WatchedCDXSourceTest.java
@@ -17,7 +17,8 @@ import junit.framework.TestCase;
 
 public class WatchedCDXSourceTest extends TestCase {
 	private static final Logger LOGGER = Logger.getLogger(WatchedCDXSourceTest.class.getName());
-	private static long WAIT = 100L;
+	private long WAIT = 100L;
+	private int NUM_TESTS = 10; 
 	WatchedCDXSource cdxSource;
 	Path cdxDir;
 	int cdxCount;
@@ -27,6 +28,7 @@ public class WatchedCDXSourceTest extends TestCase {
 		if (System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0) {
 			isMac = true;
 			WAIT = 10500L;
+			NUM_TESTS = 1;
 		}
 	}
 
@@ -102,12 +104,10 @@ public class WatchedCDXSourceTest extends TestCase {
 	public void testAddSources() throws InterruptedException {
 		cdxSource.setRecursive(false);
 		cdxSource.setPath(cdxDir.toString());
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < NUM_TESTS; i++) {
 			addCdx(cdxDir);
 			Thread.sleep(WAIT);
 			assertEquals(cdxCount, cdxSource.getSources().size());
-			if (isMac)
-				break;
 		}
 	}
 
@@ -141,12 +141,10 @@ public class WatchedCDXSourceTest extends TestCase {
 		cdxSource.setRecursive(false);
 		cdxSource.setPath(cdxDir.toString());
 		ArrayList<Path> paths = new ArrayList<Path>();
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < NUM_TESTS; i++) {
 			paths.add(addCdx(cdxDir));
 			Thread.sleep(WAIT);
 			assertEquals(cdxCount, cdxSource.getSources().size());
-			if (isMac)
-				break;
 		}
 		try {
 			for (Path p : paths) {
@@ -172,12 +170,10 @@ public class WatchedCDXSourceTest extends TestCase {
 		cdxSource.setRecursive(true);
 		cdxSource.setPath(cdxDir.toString());
 		Path newDir = addSubdirectory();
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < NUM_TESTS; i++) {
 			addCdx(newDir);
 			Thread.sleep(WAIT);
 			assertEquals(cdxCount, cdxSource.getSources().size());
-			if (isMac)
-				break;
 		}
 	}
 
@@ -193,12 +189,10 @@ public class WatchedCDXSourceTest extends TestCase {
 		cdxSource.setRecursive(false);
 		cdxSource.setPath(cdxDir.toString());
 		Path newDir = addSubdirectory();
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < NUM_TESTS; i++) {
 			addCdx(newDir);
 			Thread.sleep(WAIT);
 			assertEquals(0, cdxSource.getSources().size());
-			if (isMac)
-				break;
 		}
 	}
 

--- a/wayback-core/src/test/java/org/archive/wayback/resourceindex/WatchedCDXSourceTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/resourceindex/WatchedCDXSourceTest.java
@@ -16,213 +16,222 @@ import java.util.logging.Logger;
 import junit.framework.TestCase;
 
 public class WatchedCDXSourceTest extends TestCase {
-    private static final Logger LOGGER = Logger
-            .getLogger(WatchedCDXSourceTest.class.getName());
-    private static final long WAIT = 2500L;
-    WatchedCDXSource cdxSource;
-    Path cdxDir;
-    int cdxCount;
+	private static final Logger LOGGER = Logger.getLogger(WatchedCDXSourceTest.class.getName());
+	private static long WAIT = 100L;
+	WatchedCDXSource cdxSource;
+	Path cdxDir;
+	int cdxCount;
+	boolean isMac = false;
 
-    @Override
-    protected void setUp() {
-        cdxSource = new WatchedCDXSource();
-        cdxCount = 0;
+	public WatchedCDXSourceTest() {
+		if (System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0) {
+			isMac = true;
+			WAIT = 10500L;
+		}
+	}
 
-        String tmp = System.getProperty("java.io.tmpdir");
-        cdxDir = Paths.get(tmp + File.separator
-                + Long.toString(System.nanoTime()));
-        try {
-            cdxDir = Files.createDirectory(cdxDir);
-        } catch (IOException e) {
-            fail("Error creating CDX directory: " + e.getMessage());
-        }
-    }
+	@Override
+	protected void setUp() {
+		cdxSource = new WatchedCDXSource();
+		cdxCount = 0;
 
-    private Path addCdx(Path dir) {
-        Path newPath = null;
-        try {
-            newPath = Files.createTempFile(dir,
-                    Long.toString(System.nanoTime()), ".cdx");
-            cdxCount++;
-            LOGGER.finest("CDXs: " + cdxCount);
-        } catch (IOException e) {
-            fail("Error creating CDX file: " + e.getMessage());
-        }
-        return newPath;
-    }
+		String tmp = System.getProperty("java.io.tmpdir");
+		cdxDir = Paths.get(tmp + File.separator + Long.toString(System.nanoTime()));
+		try {
+			cdxDir = Files.createDirectory(cdxDir);
+		} catch (IOException e) {
+			fail("Error creating CDX directory: " + e.getMessage());
+		}
+	}
 
-    private Path addNonCdx(Path dir) {
-        Path newPath = null;
-        try {
-            newPath = Files.createTempFile(dir,
-                    Long.toString(System.nanoTime()), ".tmp");
-        } catch (IOException e) {
-            fail("Error creating temp. file: " + e.getMessage());
-        }
-        return newPath;
-    }
+	private Path addCdx(Path dir) {
+		Path newPath = null;
+		try {
+			newPath = Files.createTempFile(dir, Long.toString(System.nanoTime()), ".cdx");
+			cdxCount++;
+			LOGGER.finest("CDXs: " + cdxCount);
+		} catch (IOException e) {
+			fail("Error creating CDX file: " + e.getMessage());
+		}
+		return newPath;
+	}
 
-    protected Path addSubdirectory() {
-        Path newDir = null;
-        try {
-            newDir = Files.createDirectory(Paths.get(cdxDir + File.separator
-                    + Long.toString(System.nanoTime())));
-        } catch (IOException e) {
-            fail("Error creating CDX file: " + e.getMessage());
-        }
-        return newDir;
-    }
+	private Path addNonCdx(Path dir) {
+		Path newPath = null;
+		try {
+			newPath = Files.createTempFile(dir, Long.toString(System.nanoTime()), ".tmp");
+		} catch (IOException e) {
+			fail("Error creating temp. file: " + e.getMessage());
+		}
+		return newPath;
+	}
 
-    /**
-     * Test method for
-     * {@link org.archive.wayback.resourceindex.WatchedCDXSource#addExistingSources(java.nio.file.Path)}
-     * .
-     * 
-     * @throws IOException
-     * 
-     */
-    public void testExistingSources() throws IOException {
-        addCdx(cdxDir);
-        cdxSource.setRecursive(false);
-        cdxSource.setPath(cdxDir.toString());
-        assertEquals(1, cdxSource.sources.size());
-    }
+	protected Path addSubdirectory() {
+		Path newDir = null;
+		try {
+			newDir = Files.createDirectory(Paths.get(cdxDir + File.separator + Long.toString(System.nanoTime())));
+		} catch (IOException e) {
+			fail("Error creating CDX file: " + e.getMessage());
+		}
+		return newDir;
+	}
 
-    /**
-     * Test method for ENTRY_CREATE in
-     * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
-     * .
-     * 
-     * @throws InterruptedException
-     * 
-     */
-    public void testAddSources() throws InterruptedException {
-        cdxSource.setRecursive(false);
-        cdxSource.setPath(cdxDir.toString());
-        for (int i = 0; i < 10; i++) {
-            addCdx(cdxDir);
-            Thread.sleep(WAIT);
-            assertEquals(cdxCount, cdxSource.getSources().size());
-        }
-    }
+	/**
+	 * Test method for
+	 * {@link org.archive.wayback.resourceindex.WatchedCDXSource#addExistingSources(java.nio.file.Path)}
+	 * .
+	 * 
+	 * @throws IOException
+	 * 
+	 */
+	public void testExistingSources() throws IOException {
+		addCdx(cdxDir);
+		cdxSource.setRecursive(false);
+		cdxSource.setPath(cdxDir.toString());
+		assertEquals(1, cdxSource.sources.size());
+	}
 
-    /**
-     * Test method for non-CDX ENTRY_CREATE in
-     * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
-     * .
-     * 
-     * @throws InterruptedException
-     * 
-     */
-    public void testAddNonCDXSources() throws InterruptedException {
-        cdxSource.setRecursive(false);
-        cdxSource.setPath(cdxDir.toString());
-        addCdx(cdxDir);
-        Thread.sleep(WAIT);
-        addNonCdx(cdxDir);
-        Thread.sleep(WAIT);
-        assertEquals(1, cdxSource.getSources().size());
-    }
+	/**
+	 * Test method for ENTRY_CREATE in
+	 * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
+	 * .
+	 * 
+	 * @throws InterruptedException
+	 * 
+	 */
+	public void testAddSources() throws InterruptedException {
+		cdxSource.setRecursive(false);
+		cdxSource.setPath(cdxDir.toString());
+		for (int i = 0; i < 10; i++) {
+			addCdx(cdxDir);
+			Thread.sleep(WAIT);
+			assertEquals(cdxCount, cdxSource.getSources().size());
+			if (isMac)
+				break;
+		}
+	}
 
-    /**
-     * Test method for ENTRY_DELETE in
-     * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
-     * .
-     * 
-     * @throws InterruptedException
-     * 
-     */
-    public void testRemoveSources() throws InterruptedException {
-        cdxSource.setRecursive(false);
-        cdxSource.setPath(cdxDir.toString());
-        ArrayList<Path> paths = new ArrayList<Path>();
-        for (int i = 0; i < 10; i++) {
-            paths.add(addCdx(cdxDir));
-            Thread.sleep(WAIT);
-            assertEquals(cdxCount, cdxSource.getSources().size());
-        }
-        try {
-            for (Path p : paths) {
-                Files.delete(p);
-                cdxCount--;
-                Thread.sleep(WAIT);
-                assertEquals(cdxCount, cdxSource.sources.size());
-            }
-        } catch (IOException e) {
-            fail("Error deleting CDX file: " + e.getMessage());
-        }
-    }
+	/**
+	 * Test method for non-CDX ENTRY_CREATE in
+	 * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
+	 * .
+	 * 
+	 * @throws InterruptedException
+	 * 
+	 */
+	public void testAddNonCDXSources() throws InterruptedException {
+		cdxSource.setRecursive(false);
+		cdxSource.setPath(cdxDir.toString());
+		addCdx(cdxDir);
+		Thread.sleep(WAIT);
+		addNonCdx(cdxDir);
+		Thread.sleep(WAIT);
+		assertEquals(1, cdxSource.getSources().size());
+	}
 
-    /**
-     * Test method for recursive ENTRY_CREATE in
-     * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
-     * .
-     * 
-     * @throws InterruptedException
-     * 
-     */
-    public void testSubdirectoryAddSources() throws InterruptedException {
-        cdxSource.setRecursive(true);
-        cdxSource.setPath(cdxDir.toString());
-        Path newDir = addSubdirectory();
-        for (int i = 0; i < 10; i++) {
-            addCdx(newDir);
-            Thread.sleep(WAIT);
-            assertEquals(cdxCount, cdxSource.getSources().size());
-        }
-    }
+	/**
+	 * Test method for ENTRY_DELETE in
+	 * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
+	 * .
+	 * 
+	 * @throws InterruptedException
+	 * 
+	 */
+	public void testRemoveSources() throws InterruptedException {
+		cdxSource.setRecursive(false);
+		cdxSource.setPath(cdxDir.toString());
+		ArrayList<Path> paths = new ArrayList<Path>();
+		for (int i = 0; i < 10; i++) {
+			paths.add(addCdx(cdxDir));
+			Thread.sleep(WAIT);
+			assertEquals(cdxCount, cdxSource.getSources().size());
+			if (isMac)
+				break;
+		}
+		try {
+			for (Path p : paths) {
+				Files.delete(p);
+				cdxCount--;
+				Thread.sleep(WAIT);
+				assertEquals(cdxCount, cdxSource.sources.size());
+			}
+		} catch (IOException e) {
+			fail("Error deleting CDX file: " + e.getMessage());
+		}
+	}
 
-    /**
-     * Test method for non-recursive ENTRY_CREATE in
-     * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
-     * .
-     * 
-     * @throws InterruptedException
-     * 
-     */
-    public void testSubdirectoryAddSourcesNonRecursive() throws InterruptedException {
-        cdxSource.setRecursive(false);
-        cdxSource.setPath(cdxDir.toString());
-        Path newDir = addSubdirectory();
-        for (int i = 0; i < 10; i++) {
-            addCdx(newDir);
-            Thread.sleep(WAIT);
-            assertEquals(0, cdxSource.getSources().size());
-        }
-    }
+	/**
+	 * Test method for recursive ENTRY_CREATE in
+	 * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
+	 * .
+	 * 
+	 * @throws InterruptedException
+	 * 
+	 */
+	public void testSubdirectoryAddSources() throws InterruptedException {
+		cdxSource.setRecursive(true);
+		cdxSource.setPath(cdxDir.toString());
+		Path newDir = addSubdirectory();
+		for (int i = 0; i < 10; i++) {
+			addCdx(newDir);
+			Thread.sleep(WAIT);
+			assertEquals(cdxCount, cdxSource.getSources().size());
+			if (isMac)
+				break;
+		}
+	}
 
-    @Override
-    protected void tearDown() {
-        try {
-            Files.walkFileTree(cdxDir, new SimpleFileVisitor<Path>() {
-                @Override
-                public FileVisitResult visitFile(Path file,
-                        BasicFileAttributes attrs) throws IOException {
-                    Files.delete(file);
-                    try {
-                        Thread.sleep(WAIT);
-                    } catch (InterruptedException e) {
-                        fail("Error deleting CDX file: " + e.getMessage());
-                    }
-                    return CONTINUE;
-                }
+	/**
+	 * Test method for non-recursive ENTRY_CREATE in
+	 * {@link org.archive.wayback.resourceindex.WatchedCDXSource.WatcherThread)}
+	 * .
+	 * 
+	 * @throws InterruptedException
+	 * 
+	 */
+	public void testSubdirectoryAddSourcesNonRecursive() throws InterruptedException {
+		cdxSource.setRecursive(false);
+		cdxSource.setPath(cdxDir.toString());
+		Path newDir = addSubdirectory();
+		for (int i = 0; i < 10; i++) {
+			addCdx(newDir);
+			Thread.sleep(WAIT);
+			assertEquals(0, cdxSource.getSources().size());
+			if (isMac)
+				break;
+		}
+	}
 
-                @Override
-                public FileVisitResult postVisitDirectory(Path dir,
-                        IOException exc) {
-                    try {
-                        Files.delete(dir);
-                        Thread.sleep(WAIT);
-                    } catch (IOException e) {
-                        fail("Error deleting CDX dir.: " + e.getMessage());
-                    } catch (InterruptedException e) {
-                        fail("Error deleting CDX dir.: " + e.getMessage());
-                    }
-                    return CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            fail("Error tearing down: " + e.getMessage());
-        }
-    }
+	@Override
+	protected void tearDown() {
+		try {
+			Files.walkFileTree(cdxDir, new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+					Files.delete(file);
+					try {
+						Thread.sleep(WAIT);
+					} catch (InterruptedException e) {
+						fail("Error deleting CDX file: " + e.getMessage());
+					}
+					return CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+					try {
+						Files.delete(dir);
+						Thread.sleep(WAIT);
+					} catch (IOException e) {
+						fail("Error deleting CDX dir.: " + e.getMessage());
+					} catch (InterruptedException e) {
+						fail("Error deleting CDX dir.: " + e.getMessage());
+					}
+					return CONTINUE;
+				}
+			});
+		} catch (IOException e) {
+			fail("Error tearing down: " + e.getMessage());
+		}
+	}
 }

--- a/wayback-core/src/test/java/org/archive/wayback/resourceindex/WatchedCDXSourceTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/resourceindex/WatchedCDXSourceTest.java
@@ -18,6 +18,7 @@ import junit.framework.TestCase;
 public class WatchedCDXSourceTest extends TestCase {
     private static final Logger LOGGER = Logger
             .getLogger(WatchedCDXSourceTest.class.getName());
+    private static final long WAIT = 2500L;
     WatchedCDXSource cdxSource;
     Path cdxDir;
     int cdxCount;
@@ -100,7 +101,7 @@ public class WatchedCDXSourceTest extends TestCase {
         cdxSource.setPath(cdxDir.toString());
         for (int i = 0; i < 10; i++) {
             addCdx(cdxDir);
-            Thread.sleep(100L);
+            Thread.sleep(WAIT);
             assertEquals(cdxCount, cdxSource.getSources().size());
         }
     }
@@ -117,9 +118,9 @@ public class WatchedCDXSourceTest extends TestCase {
         cdxSource.setRecursive(false);
         cdxSource.setPath(cdxDir.toString());
         addCdx(cdxDir);
-        Thread.sleep(100L);
+        Thread.sleep(WAIT);
         addNonCdx(cdxDir);
-        Thread.sleep(100L);
+        Thread.sleep(WAIT);
         assertEquals(1, cdxSource.getSources().size());
     }
 
@@ -137,14 +138,14 @@ public class WatchedCDXSourceTest extends TestCase {
         ArrayList<Path> paths = new ArrayList<Path>();
         for (int i = 0; i < 10; i++) {
             paths.add(addCdx(cdxDir));
-            Thread.sleep(100L);
+            Thread.sleep(WAIT);
             assertEquals(cdxCount, cdxSource.getSources().size());
         }
         try {
             for (Path p : paths) {
                 Files.delete(p);
                 cdxCount--;
-                Thread.sleep(100L);
+                Thread.sleep(WAIT);
                 assertEquals(cdxCount, cdxSource.sources.size());
             }
         } catch (IOException e) {
@@ -166,7 +167,7 @@ public class WatchedCDXSourceTest extends TestCase {
         Path newDir = addSubdirectory();
         for (int i = 0; i < 10; i++) {
             addCdx(newDir);
-            Thread.sleep(100L);
+            Thread.sleep(WAIT);
             assertEquals(cdxCount, cdxSource.getSources().size());
         }
     }
@@ -185,7 +186,7 @@ public class WatchedCDXSourceTest extends TestCase {
         Path newDir = addSubdirectory();
         for (int i = 0; i < 10; i++) {
             addCdx(newDir);
-            Thread.sleep(100L);
+            Thread.sleep(WAIT);
             assertEquals(0, cdxSource.getSources().size());
         }
     }
@@ -199,7 +200,7 @@ public class WatchedCDXSourceTest extends TestCase {
                         BasicFileAttributes attrs) throws IOException {
                     Files.delete(file);
                     try {
-                        Thread.sleep(100L);
+                        Thread.sleep(WAIT);
                     } catch (InterruptedException e) {
                         fail("Error deleting CDX file: " + e.getMessage());
                     }
@@ -211,7 +212,7 @@ public class WatchedCDXSourceTest extends TestCase {
                         IOException exc) {
                     try {
                         Files.delete(dir);
-                        Thread.sleep(100L);
+                        Thread.sleep(WAIT);
                     } catch (IOException e) {
                         fail("Error deleting CDX dir.: " + e.getMessage());
                     } catch (InterruptedException e) {


### PR DESCRIPTION
Fixes #271. Increases the timeout for tests to 10.5 seconds on Macs but only runs a single test (normally running 10).