### PR TITLE
FIX #283: UTF-8 BOM is never detected correctly.

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/replay/charset/ByteOrderMarkSniffer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/charset/ByteOrderMarkSniffer.java
@@ -22,11 +22,11 @@ public class ByteOrderMarkSniffer extends BaseEncodingSniffer {
 		} catch (IOException ex) {
 			return null;
 		}
-		if (bbuffer[0] == 0xFE && bbuffer[1] == 0xFF)
+		if (bbuffer[0] == (byte)0xFE && bbuffer[1] == (byte)0xFF)
 			return "UTF-16BE";
-		if (bbuffer[0] == 0xFF && bbuffer[1] == 0xFE)
+		if (bbuffer[0] == (byte)0xFF && bbuffer[1] == (byte)0xFE)
 			return "UTF-16LE";
-		if (bbuffer[0] == 0xEF && bbuffer[1] == 0xBB && bbuffer[1] == 0xBF)
+		if (bbuffer[0] == (byte)0xEF && bbuffer[1] == (byte)0xBB && bbuffer[2] == (byte)0xBF)
 			return "UTF-8";
 		return null;
 	}

--- a/wayback-core/src/test/java/org/archive/wayback/replay/charset/ByteOrderMarkSnifferTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/charset/ByteOrderMarkSnifferTest.java
@@ -1,0 +1,53 @@
+package org.archive.wayback.replay.charset;
+
+import java.io.IOException;
+
+import junit.framework.TestCase;
+
+import org.archive.io.warc.TestWARCReader;
+import org.archive.io.warc.TestWARCRecordInfo;
+import org.archive.io.warc.WARCRecord;
+import org.archive.wayback.core.Resource;
+import org.archive.wayback.resourcestore.resourcefile.WarcResource;
+
+public class ByteOrderMarkSnifferTest extends TestCase {
+
+	ByteOrderMarkSniffer cut;
+	Resource resource;
+
+	protected void setUp() throws Exception {
+		cut = new ByteOrderMarkSniffer();
+	}
+
+	protected void setupResource(byte[] payload) throws IOException {
+		TestWARCRecordInfo recinfo = TestWARCRecordInfo.createHttpResponse("text/html", payload);
+		TestWARCReader ar = new TestWARCReader(recinfo);
+		WARCRecord rec = ar.get(0);
+		resource = new WarcResource(rec, ar);
+		resource.parseHeaders();
+	}
+
+	public void testUTF16BE() throws Exception {
+		setupResource(new byte[] { (byte)0xFE, (byte)0xFF, '<', 'H', 'T', 'M', 'L', '>', '<', '/', 'H', 'T', 'M', 'L', '>' });
+		String detected = cut.sniff(resource);
+		assertEquals("UTF-16BE", detected);
+	}
+
+	public void testUTF16LE() throws Exception {
+		setupResource(new byte[] { (byte)0xFF, (byte)0xFE, '<', 'H', 'T', 'M', 'L', '>', '<', '/', 'H', 'T', 'M', 'L', '>' });
+		String detected = cut.sniff(resource);
+		assertEquals("UTF-16LE", detected);
+	}
+
+	public void testUTF8() throws Exception {
+		setupResource(new byte[] { (byte)0xEF, (byte)0xBB, (byte)0xBF, '<', 'H', 'T', 'M', 'L', '>', '<', '/', 'H', 'T', 'M', 'L', '>' });
+		String detected = cut.sniff(resource);
+		assertEquals("UTF-8", detected);
+	}
+
+	public void testNoBOM() throws Exception {
+		setupResource(new byte[] { '<', 'H', 'T', 'M', 'L', '>', '<', '/', 'H', 'T', 'M', 'L', '>' });
+		String detected = cut.sniff(resource);
+		assertNull(detected);
+	}
+}


### PR DESCRIPTION
Also added a test for `ByteOrderMarkSniffer`.
