### PR TITLE
Stop using Travis legacy infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: java
 
 jdk:


### PR DESCRIPTION
http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade

Since we aren't using sudo,this is a very minor change to our build setup.

Main advantage is that this should cause builds to start quicker.