### PR TITLE
Fix for #292 Date range queries

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrl.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrl.java
@@ -49,19 +49,34 @@ public class ArchivalUrl {
 		}
 		return toPrefixQueryString(wbRequest.getRequestUrl()); 			
 	}
+    
 	public String toPrefixQueryString(String url) {
 		return toQueryString(url) + STAR;
 	}
+    
 	public String toQueryString(String url) {
 		String datespec = STAR;
-		if((wbRequest.getStartTimestamp() != null) && 
-				(wbRequest.getEndTimestamp() != null)) {
-			datespec = String.format("%s-%s%s",
-					wbRequest.getStartTimestamp(),wbRequest.getEndTimestamp(),
-					STAR);
-		}
-		return toString(datespec,url);
+        
+        String exactDateTimestamp = getEmptyStringIfNull(wbRequest.get(WaybackRequest.REQUEST_EXACT_DATE));
+        String startTimestamp = getEmptyStringIfNull(wbRequest.getStartTimestamp());
+        String endTimestamp = getEmptyStringIfNull(wbRequest.getEndTimestamp());
+        
+        if (!exactDateTimestamp.isEmpty()) {
+            datespec = exactDateTimestamp + STAR;
+        } else if (!startTimestamp.isEmpty() || !endTimestamp.isEmpty()) {
+            datespec = String.format("%s-%s%s", startTimestamp, endTimestamp, STAR);
+        }
+        
+		return toString(datespec, url);
 	}
+    
+    private String getEmptyStringIfNull(String string) {
+        if (string == null) {
+            return "";
+        } else {
+            return string;
+        }
+    }
 
 	public String toReplayString(String url) {
 		return toString(wbRequest.getReplayTimestamp(),url);

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/requestparser/ArchivalUrlFormRequestParser.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/requestparser/ArchivalUrlFormRequestParser.java
@@ -44,13 +44,6 @@ public class ArchivalUrlFormRequestParser extends FormRequestParser {
 			AccessPoint accessPoint) throws BetterRequestException {
 		WaybackRequest wbRequest = super.parse(httpRequest, accessPoint);
 		if (wbRequest != null) {
-			String replayTimestamp = wbRequest.getReplayTimestamp();
-			if ((replayTimestamp == null) || replayTimestamp.length() == 0) {
-				// lets call it a star query:
-				// TODO: should we clone?
-				wbRequest.setStartTimestamp(null);
-				wbRequest.setEndTimestamp(null);
-			}
 			String requestPath = 
 				accessPoint.translateRequestPathQuery(httpRequest);
 			ArchivalUrl aUrl = new ArchivalUrl(wbRequest);

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/requestparser/PathDateRangeQueryRequestParser.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/requestparser/PathDateRangeQueryRequestParser.java
@@ -41,7 +41,7 @@ public class PathDateRangeQueryRequestParser extends DateUrlPathRequestParser {
 		super(wrapped);
 	}
 
-	private final static Pattern TIMESTAMP_REGEX = Pattern.compile("(\\d{1,14})-(\\d{1,14})\\*");
+	private final static Pattern TIMESTAMP_REGEX = Pattern.compile("(\\d{0,14})-(\\d{0,14})\\*");
 
 	@Override
 	protected WaybackRequest parseDateUrl(String dateStr, String urlStr) {

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/requestparser/PathPrefixDateRangeQueryRequestParser.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/requestparser/PathPrefixDateRangeQueryRequestParser.java
@@ -40,7 +40,7 @@ public class PathPrefixDateRangeQueryRequestParser extends DateUrlPathRequestPar
 		super(wrapped);
 	}
 
-	private final static Pattern TIMESTAMP_REGEX = Pattern.compile("(\\d{1,14})-(\\d{1,14})\\*");
+	private final static Pattern TIMESTAMP_REGEX = Pattern.compile("(\\d{0,14})-(\\d{0,14})\\*");
 
 	@Override
 	protected WaybackRequest parseDateUrl(String dateStr, String urlStr) {

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlTest.java
@@ -65,9 +65,17 @@ public class ArchivalUrlTest extends TestCase {
 	    
 	    assertEquals("20100101000000-20101231235959*/http://www.yahoo.com/", au.toString());
 	    
-	    // same as "*" if either startTimestamp or endTimestamp is null
+	    // Open ended date ranges
 	    wbr.setEndTimestamp(null);
-	    assertEquals("*/http://www.yahoo.com/", au.toString());
+	    assertEquals("20100101000000-*/http://www.yahoo.com/", au.toString());
+        
+	    wbr.setStartTimestamp(null);
+	    wbr.setEndTimestamp("20101231235959");
+	    assertEquals("-20101231235959*/http://www.yahoo.com/", au.toString());
+        
+        // Query for exact date
+	    wbr.put(WaybackRequest.REQUEST_EXACT_DATE, "20100101000000");
+	    assertEquals("20100101000000*/http://www.yahoo.com/", au.toString());
 	}
 
     private WaybackRequest createReplayWaybackRequest() {


### PR DESCRIPTION
This PR prevents the nullifying of start/end dates and also enables queries on exact dates.

The existing unit test required that both start and end date should be set, otherwise it treated it as none of them where set. I loosened that by allowing open-ended dates.

This PR renders #225 obsolete, and solves #292 and partially #190.