### PR TITLE
Use trimmed filename so readers can infer format.

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/resourcefile/ResourceFactory.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/resourcefile/ResourceFactory.java
@@ -188,12 +188,12 @@ public class ResourceFactory {
 		InputStream is = new FileInputStream(raf.getFD());
 		String fPath = file.getAbsolutePath();
 		if (isArc(name)) {
-			ArchiveReader reader = ARCReaderFactory.get(fPath, is, false);
+			ArchiveReader reader = ARCReaderFactory.get(name, is, false);
 			r = ARCArchiveRecordToResource(reader.get(), reader);
 
 		} else if (isWarc(name)) {
 
-			ArchiveReader reader = WARCReaderFactory.get(fPath, is, false);
+			ArchiveReader reader = WARCReaderFactory.get(name, is, false);
 			r = WARCArchiveRecordToResource(reader.get(), reader);
 
 		} else {


### PR DESCRIPTION
The current ResourceFactory implementation [takes care to remove any .open extension](https://github.com/iipc/openwayback/blob/master/wayback-core/src/main/java/org/archive/wayback/resourcestore/resourcefile/ResourceFactory.java#L182-L185), so that 'mid-write' WARCs can be used. However, [when attempting to parse](https://github.com/iipc/openwayback/blob/master/wayback-core/src/main/java/org/archive/wayback/resourcestore/resourcefile/ResourceFactory.java#L196) it uses the original filename, which means the readers cannot infer the format correctly from the extension.

This patch just switched to using the filename without '.open' on the end, and so allows the readers to cope with both compressed and uncompressed archive files.