### PR TITLE
Adding revisit filters to the RemoteResourceIndex.

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -6,6 +6,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 
 ## OpenWayback 2.3.0 Release
 ### Features
+* Allow revisit records to be resolved when using a RemoteResourceIndex by adding WARCRevisitAnnotationFilter and ConditionalGetAnnotationFilter filters. [#304](https://github.com/iipc/openwayback/pull/304)
 * Use Markdown for documentation. [#265](https://github.com/iipc/openwayback/issues/265)
 * Display # of snapshots of a selected year in BubbleCalendar. [#256](https://github.com/iipc/openwayback/issues/256)
 * New FilenameFilter to include or exclude files using regular expressions [#237](https://github.com/iipc/openwayback/issues/237)

--- a/wayback-core/src/main/java/org/archive/wayback/resourceindex/RemoteResourceIndex.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourceindex/RemoteResourceIndex.java
@@ -44,7 +44,9 @@ import org.archive.wayback.exception.ConfigurationException;
 import org.archive.wayback.exception.ResourceIndexNotAvailableException;
 import org.archive.wayback.exception.ResourceNotInArchiveException;
 import org.archive.wayback.resourceindex.filterfactory.ClosestTrackingCaptureFilterGroup;
+import org.archive.wayback.resourceindex.filters.ConditionalGetAnnotationFilter;
 import org.archive.wayback.resourceindex.filters.SelfRedirectFilter;
+import org.archive.wayback.resourceindex.filters.WARCRevisitAnnotationFilter;
 import org.archive.wayback.util.ObjectFilter;
 import org.archive.wayback.util.ObjectFilterChain;
 import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
@@ -211,6 +213,9 @@ public class RemoteResourceIndex implements ResourceIndex {
 			SelfRedirectFilter selfRedirectFilter = new SelfRedirectFilter();
 			selfRedirectFilter.setCanonicalizer(canonicalizer);
 			filters.addFilter(selfRedirectFilter);
+
+            filters.addFilter(new WARCRevisitAnnotationFilter());
+            filters.addFilter(new ConditionalGetAnnotationFilter());
 
             filters.addFilter(closestGroup.getFilter());
 		} else {


### PR DESCRIPTION
This adds the filters needed to react to revisit records in a RemoteResourceIndex, thus allowing de-duplicated records to be re-duplicated.