### PR TITLE
add "noscript" as a valid Head tag for Toolbar insertion

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
@@ -81,7 +81,7 @@ public class FastArchivalUrlReplayParseEventHandler implements
 
 	private final String[] okHeadTags = { "![CDATA[*", "![CDATA[", "?",
 		"!DOCTYPE", "HTML", "HEAD", "BASE", "LINK", "META", "TITLE", "STYLE",
-		"SCRIPT", "BGSOUND" };
+		"SCRIPT", "NOSCRIPT", "BGSOUND" };
 	private HashMap<String, Object> okHeadTagMap = null;
 	private final static String FRAMESET_TAG = "FRAMESET";
 	private final static String BODY_TAG = "BODY";


### PR DESCRIPTION
Allows the Toolbar/Disclaimer to insert correctly on archived content that contains a "noscript" tag in the "head" section. Without this fix, the toolbar's html gets inserted in the "head" section, breaking the replay.
fixes #306 