### PR TITLE
Add srcset attrib rewrite

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -7,6 +7,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 ## OpenWayback 2.3.1 Release
 ### Bug fixes
 * Rewrite URLs in srcset attribute. [#310](https://github.com/iipc/openwayback/issues/310)
+* Add "noscript" as a valid Head tag for Toolbar insertion. [#306](https://github.com/iipc/openwayback/issues/306)
 
 ## OpenWayback 2.3.0 Release
 ### Features

--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -2,7 +2,7 @@
 
 # Release Notes
 
-Full listing of changes and bug fixes are not available prior to release 1.2.0 and between release 1.6.0 and OpeWayback 2.0.0 BETA 1 release.
+Full listing of changes and bug fixes are not available prior to release 1.2.0 and between release 1.6.0 and OpenWayback 2.0.0 BETA 1 release.
 
 ## OpenWayback 2.3.1 Release
 ### Bug fixes

--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -4,6 +4,10 @@
 
 Full listing of changes and bug fixes are not available prior to release 1.2.0 and between release 1.6.0 and OpeWayback 2.0.0 BETA 1 release.
 
+## OpenWayback 2.3.1 Release
+### Bug fixes
+* Rewrite URLs in srcset attribute. [#310](https://github.com/iipc/openwayback/issues/310)
+
 ## OpenWayback 2.3.0 Release
 ### Features
 * Allow revisit records to be resolved when using a RemoteResourceIndex by adding WARCRevisitAnnotationFilter and ConditionalGetAnnotationFilter filters. [#304](https://github.com/iipc/openwayback/pull/304)

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/StandardAttributeRewriter.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/StandardAttributeRewriter.java
@@ -224,7 +224,7 @@ public class StandardAttributeRewriter implements AttributeRewriter {
 		transformers.put("jb", jsBlockTrans);
 		transformers.put("ci", new InlineCSSStringTransformer());
 		transformers.put("mt", new MetaRefreshUrlStringTransformer());
-                transformers.put("ss", new SrcsetStringTransformer());
+		transformers.put("ss", new SrcsetStringTransformer());
 		
 		if (customTransformers != null) {
 			transformers.putAll(customTransformers);

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/StandardAttributeRewriter.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/StandardAttributeRewriter.java
@@ -16,6 +16,7 @@ import org.archive.wayback.replay.html.rules.AttributeModifyingRule;
 import org.archive.wayback.replay.html.transformer.InlineCSSStringTransformer;
 import org.archive.wayback.replay.html.transformer.JSStringTransformer;
 import org.archive.wayback.replay.html.transformer.MetaRefreshUrlStringTransformer;
+import org.archive.wayback.replay.html.transformer.SrcsetStringTransformer;
 import org.archive.wayback.replay.html.transformer.URLStringTransformer;
 import org.htmlparser.nodes.TagNode;
 
@@ -223,6 +224,7 @@ public class StandardAttributeRewriter implements AttributeRewriter {
 		transformers.put("jb", jsBlockTrans);
 		transformers.put("ci", new InlineCSSStringTransformer());
 		transformers.put("mt", new MetaRefreshUrlStringTransformer());
+                transformers.put("ss", new SrcsetStringTransformer());
 		
 		if (customTransformers != null) {
 			transformers.putAll(customTransformers);

--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/SrcsetStringTransformer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/SrcsetStringTransformer.java
@@ -1,0 +1,65 @@
+/*
+ *  This file is part of the Wayback archival access software
+ *   (http://archive-access.sourceforge.net/projects/wayback/).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual 
+ *  contributors. 
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.archive.wayback.replay.html.transformer;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.archive.wayback.replay.html.ReplayParseContext;
+import org.archive.wayback.replay.html.StringTransformer;
+
+/**
+ * {@link StringTransformer} that rewrites URLs in <code>SRCSET</code>
+ * attribute.
+ *
+ */
+public class SrcsetStringTransformer implements StringTransformer {
+
+	// this looks for "http://example.com/img/pic.jpg 150w,"
+	protected static String SRCSET_MEMBER = 
+		"\\s*(\\S+)(?:\\s*|\\s+(?:[-+]?[0-9]*\\.?[0-9]+x|[0-9]+w)\\s*)(?:,|$)";
+
+	protected static Pattern srcsetUrlPattern = Pattern.compile(SRCSET_MEMBER);
+
+	protected void patternRewrite(ReplayParseContext context, StringBuilder sb,
+			Pattern pattern, String flags) {
+		int idx = 0;
+		Matcher srcsetMemberMatcher = pattern.matcher(sb);
+		while (srcsetMemberMatcher.find(idx)) {
+			String url = srcsetMemberMatcher.group(1);
+			int urlLength = url.length();
+			int urlStart = srcsetMemberMatcher.start(1);
+			idx = srcsetMemberMatcher.end();
+			String replayUrl = context.contextualizeUrl(url, flags);
+			if (replayUrl != url) {
+				int delta = replayUrl.length() - urlLength;
+				sb.replace(urlStart, urlStart + urlLength, replayUrl);
+				// adjust start of next match as URL extends
+				idx += delta;
+			}
+		}
+	}
+
+        public String transform(ReplayParseContext context, String srcset) {
+                StringBuilder sb = new StringBuilder(srcset);
+                patternRewrite(context, sb, srcsetUrlPattern, "im_");
+                return sb.toString();
+        }
+}

--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/SrcsetStringTransformer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/SrcsetStringTransformer.java
@@ -32,34 +32,34 @@ import org.archive.wayback.replay.html.StringTransformer;
  */
 public class SrcsetStringTransformer implements StringTransformer {
 
-	// this looks for "http://example.com/img/pic.jpg 150w,"
-	protected static String SRCSET_MEMBER = 
-		"\\s*(\\S+)(?:\\s*|\\s+(?:[-+]?[0-9]*\\.?[0-9]+x|[0-9]+w)\\s*)(?:,|$)";
+    // this looks for "http://example.com/img/pic.jpg 150w,"
+    protected static String SRCSET_MEMBER =
+        "\\s*(\\S+)(?:\\s*|\\s+(?:[-+]?[0-9]*\\.?[0-9]+x|[0-9]+w)\\s*)(?:,|$)";
 
-	protected static Pattern srcsetUrlPattern = Pattern.compile(SRCSET_MEMBER);
+    protected static Pattern srcsetUrlPattern = Pattern.compile(SRCSET_MEMBER);
 
-	protected void patternRewrite(ReplayParseContext context, StringBuilder sb,
-			Pattern pattern, String flags) {
-		int idx = 0;
-		Matcher srcsetMemberMatcher = pattern.matcher(sb);
-		while (srcsetMemberMatcher.find(idx)) {
-			String url = srcsetMemberMatcher.group(1);
-			int urlLength = url.length();
-			int urlStart = srcsetMemberMatcher.start(1);
-			idx = srcsetMemberMatcher.end();
-			String replayUrl = context.contextualizeUrl(url, flags);
-			if (replayUrl != url) {
-				int delta = replayUrl.length() - urlLength;
-				sb.replace(urlStart, urlStart + urlLength, replayUrl);
-				// adjust start of next match as URL extends
-				idx += delta;
-			}
-		}
-	}
-
-        public String transform(ReplayParseContext context, String srcset) {
-                StringBuilder sb = new StringBuilder(srcset);
-                patternRewrite(context, sb, srcsetUrlPattern, "im_");
-                return sb.toString();
+    protected void patternRewrite(ReplayParseContext context, StringBuilder sb,
+            Pattern pattern, String flags) {
+        int idx = 0;
+        Matcher srcsetMemberMatcher = pattern.matcher(sb);
+        while (srcsetMemberMatcher.find(idx)) {
+            String url = srcsetMemberMatcher.group(1);
+            int urlLength = url.length();
+            int urlStart = srcsetMemberMatcher.start(1);
+            idx = srcsetMemberMatcher.end();
+            String replayUrl = context.contextualizeUrl(url, flags);
+            if (replayUrl != url) {
+                int delta = replayUrl.length() - urlLength;
+                sb.replace(urlStart, urlStart + urlLength, replayUrl);
+                // adjust start of next match as URL extends
+                idx += delta;
+            }
         }
+    }
+
+    public String transform(ReplayParseContext context, String srcset) {
+        StringBuilder sb = new StringBuilder(srcset);
+        patternRewrite(context, sb, srcsetUrlPattern, "im_");
+        return sb.toString();
+    }
 }

--- a/wayback-core/src/main/resources/org/archive/wayback/archivalurl/attribute-rewrite.properties
+++ b/wayback-core/src/main/resources/org/archive/wayback/archivalurl/attribute-rewrite.properties
@@ -17,6 +17,7 @@ BASE.HREF.type=an
 EMBED.SRC.type=oe
 IFRAME.SRC.type=if
 IMG.SRC.type=im
+IMG.SRCSET.type=ss
 INPUT.SRC.type=im
 FORM.ACTION.type=an
 FRAME.SRC.type=fw
@@ -27,6 +28,7 @@ META.URL.type=an
 OBJECT.CODEBASE.type=oe
 OBJECT.CDATA.type=oe
 SCRIPT.SRC.type=js
+SOURCE.SRCSET.type=ss
 # HTML5 -- can have data-src or data-uri attributes in any tag!
 # Can really be in any tag but for now using most common use cases
 # Experimental

--- a/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/SrcsetStringTransformerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/SrcsetStringTransformerTest.java
@@ -1,5 +1,21 @@
-/**
- * 
+/*
+ *  This file is part of the Wayback archival access software
+ *   (http://archive-access.sourceforge.net/projects/wayback/).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual 
+ *  contributors. 
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package org.archive.wayback.replay.html.transformer;
 
@@ -10,44 +26,44 @@ import junit.framework.TestCase;
 import org.archive.wayback.replay.html.transformer.JSStringTransformerTest.RecordingReplayParseContext;
 
 /**
- * unit test for {@link BlockCSSStringTransformer}.
- * 
+ * unit test for {@link SrcsetStringTransformer}.
+ *
  */
 public class SrcsetStringTransformerTest extends TestCase {
 
-	URL baseURL;
-	RecordingReplayParseContext rc;
-	SrcsetStringTransformer st;
-	
-	/* (non-Javadoc)
-	 * @see junit.framework.TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		baseURL = new URL("http://foo.com");
-		rc = new RecordingReplayParseContext(null, baseURL, null);
-		st = new SrcsetStringTransformer();
-	}
+    URL baseURL;
+    RecordingReplayParseContext rc;
+    SrcsetStringTransformer st;
 
-	public void testTransform() throws Exception {
-		final String[][] cases = new String[][] {
-				{
-					"http://example.com/files/pic-150.jpg 150w, http://example.com/files/pic.jpg 160w",
-					"http://example.com/files/pic-150.jpg",
-                                        "http://example.com/files/pic.jpg"
-				},
-				{
-					"examples/img/lg.jpg, examples/img/xl.jpg 2x",
-					"examples/img/lg.jpg",
-                                        "examples/img/xl.jpg"
-				}
-		};
-		
-		for (String[] c : cases) {
-			rc = new RecordingReplayParseContext(null, baseURL, null);
-			st.transform(rc, c[0]);
-			assertEquals(c[0], 2, rc.got.size());
-			assertEquals(c[0], c[1], rc.got.get(0));
-                        assertEquals(c[0], c[2], rc.got.get(1));
-		}
-	}
+    /* (non-Javadoc)
+    * @see junit.framework.TestCase#setUp()
+    */
+    protected void setUp() throws Exception {
+        baseURL = new URL("http://foo.com");
+        rc = new RecordingReplayParseContext(null, baseURL, null);
+        st = new SrcsetStringTransformer();
+        }
+
+    public void testTransform() throws Exception {
+        final String[][] cases = new String[][] {
+            {
+                "http://example.com/files/pic-150.jpg 150w, http://example.com/files/pic.jpg 160w",
+                "http://example.com/files/pic-150.jpg",
+                "http://example.com/files/pic.jpg"
+            },
+            {
+                "examples/img/lg.jpg, examples/img/xl.jpg 2x",
+                "examples/img/lg.jpg",
+                "examples/img/xl.jpg"
+            }
+        };
+
+        for (String[] c : cases) {
+            rc = new RecordingReplayParseContext(null, baseURL, null);
+            st.transform(rc, c[0]);
+            assertEquals(c[0], 2, rc.got.size());
+            assertEquals(c[0], c[1], rc.got.get(0));
+            assertEquals(c[0], c[2], rc.got.get(1));
+        }
+    }
 }

--- a/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/SrcsetStringTransformerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/SrcsetStringTransformerTest.java
@@ -1,0 +1,53 @@
+/**
+ * 
+ */
+package org.archive.wayback.replay.html.transformer;
+
+import java.net.URL;
+
+import junit.framework.TestCase;
+
+import org.archive.wayback.replay.html.transformer.JSStringTransformerTest.RecordingReplayParseContext;
+
+/**
+ * unit test for {@link BlockCSSStringTransformer}.
+ * 
+ */
+public class SrcsetStringTransformerTest extends TestCase {
+
+	URL baseURL;
+	RecordingReplayParseContext rc;
+	SrcsetStringTransformer st;
+	
+	/* (non-Javadoc)
+	 * @see junit.framework.TestCase#setUp()
+	 */
+	protected void setUp() throws Exception {
+		baseURL = new URL("http://foo.com");
+		rc = new RecordingReplayParseContext(null, baseURL, null);
+		st = new SrcsetStringTransformer();
+	}
+
+	public void testTransform() throws Exception {
+		final String[][] cases = new String[][] {
+				{
+					"http://example.com/files/pic-150.jpg 150w, http://example.com/files/pic.jpg 160w",
+					"http://example.com/files/pic-150.jpg",
+                                        "http://example.com/files/pic.jpg"
+				},
+				{
+					"examples/img/lg.jpg, examples/img/xl.jpg 2x",
+					"examples/img/lg.jpg",
+                                        "examples/img/xl.jpg"
+				}
+		};
+		
+		for (String[] c : cases) {
+			rc = new RecordingReplayParseContext(null, baseURL, null);
+			st.transform(rc, c[0]);
+			assertEquals(c[0], 2, rc.got.size());
+			assertEquals(c[0], c[1], rc.got.get(0));
+                        assertEquals(c[0], c[2], rc.got.get(1));
+		}
+	}
+}


### PR DESCRIPTION
This PR implements a `StringTransformer` to rewrite URLs in `srcset` attributes found in `<img>` and `<source>` tags. This will close #310.

If you want to use this code, I can update the release notes. If you want me to do that, let me know if you want me to create a new section or put it in 2.3.0 or something else.