### PR TITLE
Move Referer header field parsing in ServerRelativeArchivalRedirect to a method for easier customization

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -4,6 +4,14 @@
 
 Full listing of changes and bug fixes are not available prior to release 1.2.0 and between release 1.6.0 and OpeWayback 2.0.0 BETA 1 release.
 
+## OpenWayback 2.4.0 Release
+### Features
+* Allow for customization of the method to detect the source of Server-relative
+URL leak [internetarchive#57](https://github.com/internetarchive/wayback/issues/57)
+
+### Bug fixes
+
+
 ## OpenWayback 2.3.0 Release
 ### Features
 * Allow revisit records to be resolved when using a RemoteResourceIndex by adding WARCRevisitAnnotationFilter and ConditionalGetAnnotationFilter filters. [#304](https://github.com/iipc/openwayback/pull/304)

--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -4,7 +4,7 @@
 
 Full listing of changes and bug fixes are not available prior to release 1.2.0 and between release 1.6.0 and OpeWayback 2.0.0 BETA 1 release.
 
-## OpenWayback 2.4.0 Release
+## OpenWayback 2.3.1 Release
 ### Features
 * Allow for customization of the method to detect the source of Server-relative
 URL leak [internetarchive#57](https://github.com/internetarchive/wayback/issues/57)

--- a/wayback-core/src/test/java/org/archive/wayback/webapp/ServerRelativeArchivalRedirectTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/webapp/ServerRelativeArchivalRedirectTest.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletResponse;
 import junit.framework.TestCase;
 
 import org.archive.wayback.core.WaybackRequest;
+import org.archive.wayback.webapp.ServerRelativeArchivalRedirect.ArchivalUrlRef;
 import org.easymock.EasyMock;
 
 /**
@@ -108,4 +109,79 @@ public class ServerRelativeArchivalRedirectTest extends TestCase {
 		assertTrue(handled);
 	}
 
+	public static class Extended extends ServerRelativeArchivalRedirect {
+		ArchivalUrlRef ref;
+		public Extended(ArchivalUrlRef ref) {
+			this.ref = ref;
+		}
+		protected ArchivalUrlRef getOrigin(HttpServletRequest httpRequest) {
+			ArchivalUrlRef ref = super.getOrigin(httpRequest);
+			if (ref == null) {
+				// imaging getting this value from somewhere...
+				ref = this.ref;
+			}
+			return ref;
+		};
+	}
+
+	/**
+	 * Test customization by sub-classing.
+	 * @throws Exception
+	 */
+	public void testCustomOrigin() throws Exception {
+		final String ROOT = "http://web.archive.org";
+		final String COLLECTION = "/web";
+		final String DATESPEC = "20010203040506";
+		final String TARGET_BASE = "http://example.com";
+		final String REQUEST_URI = "/js/s_code.js";
+
+		final String EXPECTED_REDIRECT_URL = ROOT + COLLECTION + "/" +
+				DATESPEC + "/" + TARGET_BASE + REQUEST_URI;
+
+		// Replace cut
+		cut = new Extended(new ArchivalUrlRef(ROOT, COLLECTION,
+			DATESPEC, TARGET_BASE + "/index.html"));
+		// in current deployment matchHost is not set (=null)
+		cut.setMatchPort(80);
+		cut.setUseCollection(true);
+
+		// mocks - no Referer
+		setUpRequest(REQUEST_URI, null);
+
+		HttpServletResponse response = EasyMock.createMock(HttpServletResponse.class);
+		response.addHeader("Vary", "Referer");
+		EasyMock.expectLastCall().once();
+		response.sendRedirect(EXPECTED_REDIRECT_URL);
+		EasyMock.expectLastCall().once();
+
+		EasyMock.replay(request, response);
+
+		boolean handled = cut.handleRequest(request, response);
+
+		EasyMock.verify(response);
+		assertTrue(handled);
+	}
+
+	/**
+	 * Test of non-ArchivalUrl requests.
+	 * ServerRelativeArchivalRedirect is setup as catch-all handler ("{@code +"}).
+	 * It must handle non-replay URLs like {@code /} and {@code /favicon.ico}, with
+	 * non-ArchivalUrl Referer. It must not fail, and return {@code false}.
+	 * @throws Exception
+	 */
+	public void testNonArchivalUrl() throws Exception {
+		final String REQUEST_URI = "/";
+		final String REFERER = "http://www.example.com/index.html";
+
+		setUpRequest(REQUEST_URI, REFERER);
+
+		HttpServletResponse response = EasyMock.createMock(HttpServletResponse.class);
+		// no actions on response
+		EasyMock.replay(request, response);
+
+		boolean handled = cut.handleRequest(request, response);
+
+		EasyMock.verify(response);
+		assertFalse(handled);
+	}
 }


### PR DESCRIPTION
We found an issue with `Referer` header generated by Flash plugin for Firefox and want to extend `ServerRelativeArchivalRedirect` with experimental method of obtaining ArchivalUrl context. Unfortunately `ServerRelativeArchivalRedirect` does not have extension point for this purpose.

This patch separates out `Referer` parsing in `handleRequestWithCollection` into a protected method, so that developer can extend ServerRelativeArchivalRedirect with experimental leak-source detection mechanism.

See also: internetarchive/wayback#57
