### PR TITLE
EmbeddedCDXServerIndex: pass matchType=exact explicitly

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/resourceindex/cdxserver/EmbeddedCDXServerIndex.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourceindex/cdxserver/EmbeddedCDXServerIndex.java
@@ -308,6 +308,10 @@ public class EmbeddedCDXServerIndex extends AbstractRequestHandler implements Me
 			if (wbRequest.isTimestampSearchKey()) {
 				query.setClosest(wbRequest.getReplayTimestamp());
 			}
+
+			// set explicit matchType, or CDXServer will run prefix
+			// query when URL ends with "*".
+			query.setMatchType(MatchType.exact);
 		} else if (wbRequest.isCaptureQueryRequest()) {
 			// Add support for range calendar queries:
 			// eg: /2005-2007*/


### PR DESCRIPTION
to prevent CDXServer from interpreting URL with trailing
asterisk as prefix query.

I knew playback would fail if URL has trailing asterisk, but we hit a real example.

See also: https://github.com/internetarchive/wayback/issues/80
