### PR TITLE
Allow any elements to happen inside NOSCRIPT without triggering bodyInsert.

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
@@ -87,6 +87,12 @@ public class FastArchivalUrlReplayParseEventHandler implements
 	private final static String BODY_TAG = "BODY";
 
 	protected static final String FERRET_HEAD_INSERTED = "FERRET_HEAD_INSERTED";
+	
+	/**
+	 * The key in {@code context} for storing state being inside a <NOSCRIPT> element.
+	 * (inside <HEAD> only).
+	 */
+	protected static final String STATE_IN_NOSCRIPT = "STATE_NO_SCRIPT";
 
 	private BlockCSSStringTransformer cssBlockTrans = new BlockCSSStringTransformer();
 	private StringTransformer jsBlockTrans = new JSStringTransformer();
@@ -158,6 +164,10 @@ public class FastArchivalUrlReplayParseEventHandler implements
 			if (tagNode.isEndTag()) {
 				if (tagNode.getTagName().equals("HEAD")) {
 					context.putData(FERRET_IN_HEAD, null);
+					// turn off NOSCIPT state as well. It's inside HEAD only.
+					context.putData(STATE_IN_NOSCRIPT, null);
+				} else if (tagNode.getTagName().equals("NOSCRIPT")) {
+					context.putData(STATE_IN_NOSCRIPT, null);
 				}
 
 				if (checkAllowTag(pContext, tagNode)) {
@@ -256,6 +266,7 @@ public class FastArchivalUrlReplayParseEventHandler implements
 		boolean alreadyInsertedHead = (context.getData(FERRET_HEAD_INSERTED) != null);
 		boolean insertedJsp = context.getData(FERRET_DONE_KEY) != null;
 		boolean inHead = (context.getData(FERRET_IN_HEAD) != null);
+		boolean inNoScript = (context.getData(STATE_IN_NOSCRIPT) != null);
 
 		if (!alreadyInsertedHead) {
 			// If we're at the beginning of a <head> tag, and haven't inserted yet, 
@@ -277,6 +288,14 @@ public class FastArchivalUrlReplayParseEventHandler implements
 				emitHeadInsert(context, null, false);
 				// Don't return continue to further processing
 			}
+		} else if (tagName.equals("NOSCRIPT") && inHead) {
+			// NOSCRIPT under HEAD may contain elements that usually happen
+			// inside BODY. As long as they are inside NOSCRIPT, we let them go
+			// without inserting bodyInsert. Note this is NOSCRIPT under HEAD
+			// only. If <NOSCRIPT> happens before <HEAD>, non-HEAD elements in
+			// it would trigger bodyInsert. We may want to revise this behavior
+			// based on real-world examples.
+			context.putData(STATE_IN_NOSCRIPT, "");
 		} else if (tagName.equals(BODY_TAG) && inHead) {
 			context.putData(FERRET_IN_HEAD, null);
 			inHead = false;
@@ -294,7 +313,7 @@ public class FastArchivalUrlReplayParseEventHandler implements
 			} else if (tagName.equals(BODY_TAG)) {
 				postEmit = bodyInsertContent(context);
 				context.putData(FERRET_DONE_KEY, "");
-			} else if (!okHeadTagMap.containsKey(tagName)) {
+			} else if (!inNoScript && !okHeadTagMap.containsKey(tagName)) {
 				// hrm... we are seeing a node that should be in
 				// the body.. lets emit the jsp now, *before*
 				// the current Tag:

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
@@ -1000,6 +1000,75 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
 		assertEquals(expected, output);
 	}
 
+	/**
+	 * NOSCRIPT in HEAD can contain arbitrary element (we've seen IMG and IFRAME
+	 * occuring inside NOSCRIPT), and it shall not trigger injection of
+	 * body-inserts.
+	 * @throws Exception
+	 */
+	public void testNOSCRIPT() throws Exception {
+		delegator.setHeadInsertJsp("head.jsp");
+		delegator.setJspInsertPath("body-insert.jsp");
+		jspExec = new TestJSPExecutor();
+
+		final String input = "<!DOCTYPE html>\n" +
+				"<head>\n" +
+				"  <noscript>\n" +
+				"    <img height=\"1\" width=\"1\" style=\"display:none\" src=\"ping.gif\">\n" +
+				"  </noscript>\n" +
+				"</head>\n" +
+				"<body>\n" +
+				"  body body\n" +
+				"</body>\n" +
+				"</html>\n";
+		final String expected = "<!DOCTYPE html>\n" +
+				"<head>[[[JSP-INSERT:head.jsp]]]\n" +
+				"  <noscript>\n" +
+				"    <img height=\"1\" width=\"1\" style=\"display:none\" src=\"ping.gif\">\n" +
+				"  </noscript>\n" +
+				"</head>\n" +
+				"<body>[[[JSP-INSERT:body-insert.jsp]]]\n" +
+				"  body body\n" +
+				"</body>\n" +
+				"</html>\n";;
+		String out = doEndToEnd(input);
+		//System.out.println(out);
+		assertEquals(expected, out);
+	}
+
+	/**
+	 * pathological case of missing {@code </NOSCRIPT>}.
+	 * {@code </HEAD>} shall close </NOSCRIPT> as well.
+	 * @throws Exception
+	 */
+	public void testNOSCRIPT_missingCloseTag() throws Exception {
+		delegator.setHeadInsertJsp("head.jsp");
+		delegator.setJspInsertPath("body-insert.jsp");
+		jspExec = new TestJSPExecutor();
+
+		final String input = "<!DOCTYPE html>\n" +
+				"<head>\n" +
+				"  <noscript>\n" +
+				"    <img height=\"1\" width=\"1\" style=\"display:none\" src=\"ping.gif\">\n" +
+				"</head>\n" +
+				"<body>\n" +
+				"  body body\n" +
+				"</body>\n" +
+				"</html>\n";
+		final String expected = "<!DOCTYPE html>\n" +
+				"<head>[[[JSP-INSERT:head.jsp]]]\n" +
+				"  <noscript>\n" +
+				"    <img height=\"1\" width=\"1\" style=\"display:none\" src=\"ping.gif\">\n" +
+				"</head>\n" +
+				"<body>[[[JSP-INSERT:body-insert.jsp]]]\n" +
+				"  body body\n" +
+				"</body>\n" +
+				"</html>\n";;
+		String out = doEndToEnd(input);
+		//System.out.println(out);
+		assertEquals(expected, out);
+	}
+
     public String doEndToEnd(String input) throws Exception {
 		ByteArrayInputStream bais = new ByteArrayInputStream(input.getBytes(charSet));
 		


### PR DESCRIPTION
This is related to #306. We encountered cases where NOSCRIPT occurs in HEAD and it contains elements as its children that don't usually happen in HEAD directly - IMG, DIV and IFRAME. Even with #307, these child elements trigger bodyInsert and break the layout.

This patch allows arbitrary elements to occur inside NOSCRIPT without triggering bodyInsert. 

Original issue item: internetarchive/wayback#119
