### PR TITLE
Load required jQuery in noConflict mode

### DIFF
--- a/wayback-webapp/src/main/webapp/WEB-INF/replay/Toolbar.jsp
+++ b/wayback-webapp/src/main/webapp/WEB-INF/replay/Toolbar.jsp
@@ -71,6 +71,10 @@ String starLink = fmt.escapeHtml(queryPrefix + wbRequest.getReplayTimestamp() +
 <script type="text/javascript" src="<%= staticPrefix %>js/disclaim-element.js" ></script>
 <script type="text/javascript" src="<%= staticPrefix %>js/graph-calc.js" ></script>
 <script src="<%= staticPrefix %>js/jquery.mCustomScrollbar.concat.min.js" charset="utf-8"></script>
+<script>
+	<!-- Custom jQuery global variable to prevent conflict with page jQuery -->
+	jqWayback = jQuery.noConflict(true);
+</script>
 <script type="text/javascript">
 //<![CDATA[
 var firstDate = <%= firstYearDate.getTime() %>;
@@ -346,7 +350,7 @@ function trackMouseMove(event,element) {
                 }
             }
         });
-    })(jQuery);
+    })(jqWayback);
 </script>   
    
 <script type="text/javascript">


### PR DESCRIPTION
Load jQuery 1.4.2 and toolbar plugin, then define new jQuery global (`jqWayback`) and relinquish control of `$` global to prevent interference with archived page jQuery.

Fixes #356 