### PR TITLE
Docker build improvements to fix #362

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.travis.yml
+*.md
+plan.txt
+LICENSE
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,11 @@ RUN tar xvzf dist/target/openwayback.tar.gz -C dist/target \
 
 # Image creation stage
 FROM tomcat:${TOMCAT_TAG}
-LABEL project.name="OpenWayback" \
-      project.description="OpenWayback is a replay system for archived web pages." \
-      project.repo.url="https://github.com/iipc/openwayback" \
-      project.docs.url="https://github.com/iipc/openwayback/wiki" \
-      project.dockerfile.author="Sawood Alam <@ibnesayeed>"
+LABEL app.name="OpenWayback" \
+      app.description="OpenWayback is a replay system for archived web pages." \
+      app.repo.url="https://github.com/iipc/openwayback" \
+      app.docs.url="https://github.com/iipc/openwayback/wiki" \
+      app.dockerfile.author="Sawood Alam <@ibnesayeed>"
 
 RUN rm -rf /usr/local/tomcat/webapps/*
 COPY --from=builder /src/dist/target/openwayback/ROOT /usr/local/tomcat/webapps/ROOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,11 @@ RUN tar xvzf dist/target/openwayback.tar.gz -C dist/target \
 
 # Image creation stage
 FROM tomcat:${TOMCAT_TAG}
-LABEL maintainer="Sawood Alam <@ibnesayeed>"
+LABEL project.name="OpenWayback" \
+      project.description="OpenWayback is a replay system for archived web pages." \
+      project.repo.url="https://github.com/iipc/openwayback" \
+      project.docs.url="https://github.com/iipc/openwayback/wiki" \
+      project.dockerfile.author="Sawood Alam <@ibnesayeed>"
 
 RUN rm -rf /usr/local/tomcat/webapps/*
 COPY --from=builder /src/dist/target/openwayback/ROOT /usr/local/tomcat/webapps/ROOT

--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -7,7 +7,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 ## OpenWayback 2.4.0 Release
 ### Features
 * Add scrollbar to year chart in toolbar appearing in every archived webpage. [#340](https://github.com/iipc/openwayback/issues/340)
-* Add a Dockerfile for building OpenWayback. Please see the [How to build and run in Docker](https://github.com/iipc/openwayback/wiki/How-to-build-and-run-in-Docker) documentation for use. [#344](https://github.com/iipc/openwayback/pull/344)
+* Add a Dockerfile for building OpenWayback. Please see the [How to build and run in Docker](https://github.com/iipc/openwayback/wiki/How-to-build-and-run-in-Docker) documentation for use. [#344](https://github.com/iipc/openwayback/pull/344) and [#362](https://github.com/iipc/openwayback/pull/362)
 * Visualize snapshot density in bubble calendar using bubble background color. [#351](https://github.com/iipc/openwayback/issues/351)
 
 ### Bug fixes


### PR DESCRIPTION
Adding `.dockerignore` file (c84bbcb) drastically reduced the build context from 61.5 MB to 6.3 MB which improves the build time while reducing the cache invalidation surface.

Adding ahead of time dependency resolution (2b285f5) increased the first build time, but successive builds were significantly faster due to strategic cache utilization.

Before this change, every docker image build was taking about seven minutes on my machine. The time was spent mostly in downloading dependencies (less than one minute of processor time).

```
Sending build context to Docker daemon  61.54MB
...
Successfully tagged openwayback:latest

real	7m51.053s
user	0m0.672s
sys	0m0.388s
```

After the `.dockerignore` and dependency caching, first time build is taking about ten minutes while successive builds take just a little over one minute.

First build (after any changes in any of the `pom.xml` files):

```
Sending build context to Docker daemon  6.309MB
Successfully tagged openwayback:latest

real	10m8.652s
user	0m0.880s
sys	0m0.388s
```

Successive builds (after changes in other source files in the build context):

```
Sending build context to Docker daemon  6.309MB
...
Successfully tagged openwayback:latest

real	1m20.029s
user	0m0.296s
sys	0m0.116s
```

Depending on the network speed and processor, results might vary.

When merged this will close #362.

**Note:** Someone decided to make the default local repository folder of the official Docker image of Maven a volume (https://github.com/carlossg/docker-maven/issues/11). This forced me to customize the path of the local repo or else artifacts will not be cached.