### PR TITLE
Fix 371 integrity attribute

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -17,6 +17,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 * Fix inconsistent content and background image shifting with toolbar and disclaimer. [#358](https://github.com/iipc/openwayback/issues/358)
 * Fix misplaced `break` statement in WatchedCDXSource. [#369](https://github.com/iipc/openwayback/issues/369)
 * Fix toolbar plurality issue when only a single capture. [#372](https://github.com/iipc/openwayback/issues/372)
+* Rewrite `integrity` attribute for resources that implement Subresource Integrity. [#371](https://github.com/iipc/openwayback/issues/371)
 
 ## OpenWayback 2.3.2 Release
 ### Bug fixes

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/StandardAttributeRewriter.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/StandardAttributeRewriter.java
@@ -16,6 +16,7 @@ import org.archive.wayback.replay.html.rules.AttributeModifyingRule;
 import org.archive.wayback.replay.html.transformer.InlineCSSStringTransformer;
 import org.archive.wayback.replay.html.transformer.JSStringTransformer;
 import org.archive.wayback.replay.html.transformer.MetaRefreshUrlStringTransformer;
+import org.archive.wayback.replay.html.transformer.RegexReplaceStringTransformer;
 import org.archive.wayback.replay.html.transformer.SrcsetStringTransformer;
 import org.archive.wayback.replay.html.transformer.URLStringTransformer;
 import org.htmlparser.nodes.TagNode;
@@ -225,6 +226,7 @@ public class StandardAttributeRewriter implements AttributeRewriter {
 		transformers.put("ci", new InlineCSSStringTransformer());
 		transformers.put("mt", new MetaRefreshUrlStringTransformer());
 		transformers.put("ss", new SrcsetStringTransformer());
+		transformers.put("in", new RegexReplaceStringTransformer("^.*$", ""));
 		
 		if (customTransformers != null) {
 			transformers.putAll(customTransformers);

--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/RegexReplaceStringTransformer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/RegexReplaceStringTransformer.java
@@ -51,7 +51,6 @@ public class RegexReplaceStringTransformer extends RewriteRule implements
 	 * @param replacement String to use
 	 */
 	public RegexReplaceStringTransformer(String regex, String replacement) {
-		//this.regex = regex;
 		setRegex(regex);
 		this.replacement = replacement;
 	}

--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/RegexReplaceStringTransformer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/RegexReplaceStringTransformer.java
@@ -42,6 +42,20 @@ public class RegexReplaceStringTransformer extends RewriteRule implements
 	// being removed
 	private String urlScope = null;
 
+	/** Default constructor */
+	public RegexReplaceStringTransformer() {}
+
+	/**
+	 * regex/replacement setting constructor.
+	 * @param regex String to be replaced
+	 * @param replacement String to use
+	 */
+	public RegexReplaceStringTransformer(String regex, String replacement) {
+		//this.regex = regex;
+		setRegex(regex);
+		this.replacement = replacement;
+	}
+
 	public String transform(ReplayParseContext context, String input) {
 
 		if (getName() != null) {

--- a/wayback-core/src/main/resources/org/archive/wayback/archivalurl/attribute-rewrite.properties
+++ b/wayback-core/src/main/resources/org/archive/wayback/archivalurl/attribute-rewrite.properties
@@ -21,12 +21,14 @@ IMG.SRCSET.type=ss
 INPUT.SRC.type=im
 FORM.ACTION.type=an
 FRAME.SRC.type=fw
+LINK.INTEGRITY.type=in
 LINK[REL\=STYLESHEET].HREF.type=cs
 LINK[REL\=SHORTCUT\ ICON].HREF.type=im
 META[HTTP-EQUIV\=REFRESH].CONTENT.type=mt
 META.URL.type=an
 OBJECT.CODEBASE.type=oe
 OBJECT.CDATA.type=oe
+SCRIPT.INTEGRITY.type=in
 SCRIPT.SRC.type=js
 SOURCE.SRCSET.type=ss
 # HTML5 -- can have data-src or data-uri attributes in any tag!

--- a/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/RegexReplaceStringTransformerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/RegexReplaceStringTransformerTest.java
@@ -41,6 +41,12 @@ public class RegexReplaceStringTransformerTest extends TestCase {
                 "video/[a-z]*.mp4",
                 "video/changed.mp4",
                 "examples/video/changed.mp4",
+            },
+            {
+                "examples/video/test.mp4",
+                "notmatching/[a-z]*.mp4",
+                "video/changed.mp4",
+                "examples/video/test.mp4",
             }
         };
 

--- a/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/RegexReplaceStringTransformerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/RegexReplaceStringTransformerTest.java
@@ -1,0 +1,53 @@
+/*
+ *
+ */
+package org.archive.wayback.replay.html.transformer;
+
+import java.net.URL;
+
+import junit.framework.TestCase;
+
+import org.archive.wayback.replay.html.transformer.JSStringTransformerTest.RecordingReplayParseContext;
+
+/**
+ * unit test for {@link RegexReplaceStringTransformer}.
+ *
+ */
+public class RegexReplaceStringTransformerTest extends TestCase {
+
+    URL baseURL;
+    RecordingReplayParseContext rc;
+    RegexReplaceStringTransformer st;
+
+    /* (non-Javadoc)
+    * @see junit.framework.TestCase#setUp()
+    */
+    protected void setUp() throws Exception {
+        baseURL = new URL("http://foo.com");
+        rc = new RecordingReplayParseContext(null, baseURL, null);
+        }
+
+    public void testTransform() throws Exception {
+        // values are input, regex to find, replacement for regex, expected result
+        final String[][] cases = new String[][] {
+            {
+                "sha256-1LpauPYMnfXHM+fTx8Rp/5Pca2TSsqj+uUr6j3fGYZM=",
+                ".*sha256.*",
+                "",
+                "",
+            },
+            {
+                "examples/video/test.mp4",
+                "video/[a-z]*.mp4",
+                "video/changed.mp4",
+                "examples/video/changed.mp4",
+            }
+        };
+
+        for (String[] c : cases) {
+            st = new RegexReplaceStringTransformer(c[1], c[2]);
+            String result = st.transform(rc, c[0]);
+            assertEquals(c[3], result);
+        }
+    }
+}


### PR DESCRIPTION
This is to fix #371 .  The fix uses the existing `RegexReplaceStringTransformer` to replace the string value of `integrity` attributes with empty string.