### PR TITLE
Upgrade httpclient to fix #380

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -18,6 +18,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 * Fix misplaced `break` statement in WatchedCDXSource. [#369](https://github.com/iipc/openwayback/issues/369)
 * Fix toolbar plurality issue when only a single capture. [#372](https://github.com/iipc/openwayback/issues/372)
 * Rewrite `integrity` attribute for resources that implement Subresource Integrity. [#371](https://github.com/iipc/openwayback/issues/371)
+* Upgrade httpclient from 4.3.5. [#380](https://github.com/iipc/openwayback/issues/380)
 
 ## OpenWayback 2.3.2 Release
 ### Bug fixes

--- a/wayback-core/pom.xml
+++ b/wayback-core/pom.xml
@@ -128,7 +128,7 @@
     <dependency>  
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.5</version>
+      <version>4.5.6</version>
       <type>jar</type>
     </dependency>
   </dependencies>


### PR DESCRIPTION
We need to upgrade httpclient from 4.3.5. We could go to 4.3.6, but I tried the most recent release at 4.5.6 and tests passed and application was working as far as I could tell, so maybe they follow the rules of semantic versioning? I welcome a second opinion/review!