### PR TITLE
Add rewrite properties

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -20,6 +20,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 * Rewrite `integrity` attribute for resources that implement Subresource Integrity. [#371](https://github.com/iipc/openwayback/issues/371)
 * Upgrade httpclient from 4.3.5. [#380](https://github.com/iipc/openwayback/issues/380)
 * Declare Surefire plugin explicitly due to a change in a default value that breaks builds on newer versions of Maven. [#384](https://github.com/iipc/openwayback/pull/384)
+* Rewrite additional HTML5 tag attributes including `source`. [#242](https://github.com/iipc/openwayback/issues/242)
 
 ## OpenWayback 2.3.2 Release
 ### Bug fixes

--- a/wayback-core/src/main/resources/org/archive/wayback/archivalurl/attribute-rewrite.properties
+++ b/wayback-core/src/main/resources/org/archive/wayback/archivalurl/attribute-rewrite.properties
@@ -13,6 +13,7 @@ A.HREF.type=an
 APPLET.CODEBASE.type=oe
 APPLET.ARCHIVE.type=oe
 AREA.HREF.type=an
+AUDIO.SRC.type=oe
 BASE.HREF.type=an
 EMBED.SRC.type=oe
 IFRAME.SRC.type=if
@@ -30,14 +31,23 @@ OBJECT.CODEBASE.type=oe
 OBJECT.CDATA.type=oe
 SCRIPT.INTEGRITY.type=in
 SCRIPT.SRC.type=js
+SOURCE.SRC.type=oe
 SOURCE.SRCSET.type=ss
+VIDEO.POSTER.type=im
+VIDEO.SRC.type=oe
 # HTML5 -- can have data-src or data-uri attributes in any tag!
 # Can really be in any tag but for now using most common use cases
 # Experimental
 DIV.DATA-SRC.type=oe
 DIV.DATA-URI.type=oe
+IMG.DATA-SRC.type=im
 LI.DATA-SRC.type=oe
 LI.DATA-URI.type=oe
+VIDEO.DATA-SRC.type=oe
+*.DATA-MP4.type=oe
+*.DATA-OGG.type=oe
+*.DATA-THUMB.type=im
+*.DATA-WEBM.type=oe
 *.BACKGROUND.type=im
 *.STYLE.type=ci
 *.ONCLICK.type=jb

--- a/wayback-core/src/main/resources/org/archive/wayback/archivalurl/attribute-rewrite.properties
+++ b/wayback-core/src/main/resources/org/archive/wayback/archivalurl/attribute-rewrite.properties
@@ -33,6 +33,7 @@ SCRIPT.INTEGRITY.type=in
 SCRIPT.SRC.type=js
 SOURCE.SRC.type=oe
 SOURCE.SRCSET.type=ss
+TRACK.SRC.type=oe
 VIDEO.POSTER.type=im
 VIDEO.SRC.type=oe
 # HTML5 -- can have data-src or data-uri attributes in any tag!

--- a/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlSaxReplay.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlSaxReplay.xml
@@ -225,6 +225,11 @@
 					<property name="transformer" ref="srcsetAttributeHandler" />
 				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="TRACK" />
+					<property name="modifyAttributeName" value="SRC" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="VIDEO" />
 					<property name="modifyAttributeName" value="POSTER" />
 					<property name="transformer" ref="imageURLRewriter" />

--- a/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlSaxReplay.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlSaxReplay.xml
@@ -77,7 +77,6 @@
 					<property name="tagName" value="META" />
 					<property name="whereAttributeName" value="http-equiv" />
 					<property name="whereAttributeValue" value="refresh" />
-
 					<property name="modifyAttributeName" value="content" />
 					<property name="transformer" ref="metaRefreshHandler" />
 				</bean>
@@ -91,21 +90,21 @@
 					<property name="modifyAttributeName" value="SRC" />
 					<property name="transformer" ref="imageURLRewriter" />
 				</bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="IMG" />
-                                        <property name="modifyAttributeName" value="SRCSET" />
-                                        <property name="transformer" ref="srcsetAttributeHandler" />
-                                </bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="IMG" />
+					<property name="modifyAttributeName" value="SRCSET" />
+					<property name="transformer" ref="srcsetAttributeHandler" />
+				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="SCRIPT" />
 					<property name="modifyAttributeName" value="SRC" />
 					<property name="transformer" ref="jsURLRewriter" />
 				</bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="SCRIPT" />
-                                        <property name="modifyAttributeName" value="INTEGRITY" />
-                                        <property name="transformer" ref="integrityAttributeHandler" />
-                                </bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="SCRIPT" />
+					<property name="modifyAttributeName" value="INTEGRITY" />
+					<property name="transformer" ref="integrityAttributeHandler" />
+				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="BASE" />
 					<property name="modifyAttributeName" value="HREF" />
@@ -159,11 +158,11 @@
 					<property name="modifyAttributeName" value="HREF" />
 					<property name="transformer" ref="anchorURLRewriter" />
 				</bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="LINK" />
-                                        <property name="modifyAttributeName" value="INTEGRITY" />
-                                        <property name="transformer" ref="integrityAttributeHandler" />
-                                </bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="LINK" />
+					<property name="modifyAttributeName" value="INTEGRITY" />
+					<property name="transformer" ref="integrityAttributeHandler" />
+				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="AREA" />
 					<property name="modifyAttributeName" value="HREF" />
@@ -189,11 +188,11 @@
 					<property name="modifyAttributeName" value="ARCHIVE" />
 					<property name="transformer" ref="anchorURLRewriter" />
 				</bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="AUDIO" />
-                                        <property name="modifyAttributeName" value="SRC" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="AUDIO" />
+					<property name="modifyAttributeName" value="SRC" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="EMBED" />
 					<property name="modifyAttributeName" value="SRC" />
@@ -203,92 +202,92 @@
 					<property name="modifyAttributeName" value="ONCLICK" />
 					<property name="transformer" ref="jsBlockHandler" />
 				</bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="modifyAttributeName" value="ONLOAD" />
-                                        <property name="transformer" ref="jsBlockHandler" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="modifyAttributeName" value="ONCHANGE" />
-                                        <property name="transformer" ref="jsBlockHandler" />
-                                </bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="modifyAttributeName" value="ONLOAD" />
+					<property name="transformer" ref="jsBlockHandler" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="modifyAttributeName" value="ONCHANGE" />
+					<property name="transformer" ref="jsBlockHandler" />
+				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="modifyAttributeName" value="style" />
 					<property name="transformer" ref="cssAttributeHandler" />
 				</bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="SOURCE" />
-                                        <property name="modifyAttributeName" value="SRC" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="SOURCE" />
-                                        <property name="modifyAttributeName" value="SRCSET" />
-                                        <property name="transformer" ref="srcsetAttributeHandler" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="VIDEO" />
-                                        <property name="modifyAttributeName" value="POSTER" />
-                                        <property name="transformer" ref="imageURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="VIDEO" />
-                                        <property name="modifyAttributeName" value="SRC" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.StyleContentRule">
-                                        <property name="transformer" ref="cssBlockHandler" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.JSContentRule">
-                                        <property name="transformer" ref="jsBlockHandler" />
-                                </bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="SOURCE" />
+					<property name="modifyAttributeName" value="SRC" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="SOURCE" />
+					<property name="modifyAttributeName" value="SRCSET" />
+					<property name="transformer" ref="srcsetAttributeHandler" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="VIDEO" />
+					<property name="modifyAttributeName" value="POSTER" />
+					<property name="transformer" ref="imageURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="VIDEO" />
+					<property name="modifyAttributeName" value="SRC" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.StyleContentRule">
+					<property name="transformer" ref="cssBlockHandler" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.JSContentRule">
+					<property name="transformer" ref="jsBlockHandler" />
+				</bean>
 
-                                <!-- Experimental HTML5 data-* rewrites -->
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="DIV" />
-                                        <property name="modifyAttributeName" value="DATA-SRC" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="DIV" />
-                                        <property name="modifyAttributeName" value="DATA-URI" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="IMG" />
-                                        <property name="modifyAttributeName" value="DATA-SRC" />
-                                        <property name="transformer" ref="imageURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="LI" />
-                                        <property name="modifyAttributeName" value="DATA-SRC" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="LI" />
-                                        <property name="modifyAttributeName" value="DATA-URI" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="tagName" value="VIDEO" />
-                                        <property name="modifyAttributeName" value="DATA-SRC" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="modifyAttributeName" value="DATA-MP4" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="modifyAttributeName" value="DATA-OGG" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="modifyAttributeName" value="DATA-THUMB" />
-                                        <property name="transformer" ref="imageURLRewriter" />
-                                </bean>
-                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-                                        <property name="modifyAttributeName" value="DATA-WEBM" />
-                                        <property name="transformer" ref="anchorURLRewriter" />
-                                </bean>
+				<!-- Experimental HTML5 data-* rewrites -->
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="DIV" />
+					<property name="modifyAttributeName" value="DATA-SRC" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="DIV" />
+					<property name="modifyAttributeName" value="DATA-URI" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="IMG" />
+					<property name="modifyAttributeName" value="DATA-SRC" />
+					<property name="transformer" ref="imageURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="LI" />
+					<property name="modifyAttributeName" value="DATA-SRC" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="LI" />
+					<property name="modifyAttributeName" value="DATA-URI" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="VIDEO" />
+					<property name="modifyAttributeName" value="DATA-SRC" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="modifyAttributeName" value="DATA-MP4" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="modifyAttributeName" value="DATA-OGG" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+				<property name="modifyAttributeName" value="DATA-THUMB" />
+					<property name="transformer" ref="imageURLRewriter" />
+				</bean>
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="modifyAttributeName" value="DATA-WEBM" />
+					<property name="transformer" ref="anchorURLRewriter" />
+				</bean>
 			</list>
 		</property>
 	</bean>

--- a/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlSaxReplay.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlSaxReplay.xml
@@ -286,7 +286,7 @@
 					<property name="transformer" ref="anchorURLRewriter" />
 				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-				<property name="modifyAttributeName" value="DATA-THUMB" />
+					<property name="modifyAttributeName" value="DATA-THUMB" />
 					<property name="transformer" ref="imageURLRewriter" />
 				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">

--- a/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlSaxReplay.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/ArchivalUrlSaxReplay.xml
@@ -44,11 +44,17 @@
 	<bean id="jsBlockHandler"
 		class="org.archive.wayback.replay.html.transformer.JSStringTransformer">
 	</bean>
-    <bean id="metaRefreshHandler"
-            class="org.archive.wayback.replay.html.transformer.MetaRefreshUrlStringTransformer">
-    </bean>
-
-
+	<bean id="metaRefreshHandler"
+		class="org.archive.wayback.replay.html.transformer.MetaRefreshUrlStringTransformer">
+	</bean>
+	<bean id="srcsetAttributeHandler"
+		class="org.archive.wayback.replay.html.transformer.SrcsetStringTransformer">
+	</bean>
+	<bean id="integrityAttributeHandler"
+		class="org.archive.wayback.replay.html.transformer.RegexReplaceStringTransformer">
+		<property name="regex" value="^.*$" />
+		<property name="replacement" value="" />
+	</bean>
 
 	<bean id="archivalSAXDelegator"
 		class="org.archive.wayback.replay.html.ReplayParseEventDelegator">
@@ -67,39 +73,44 @@
 					<property name="jspPath" value="/WEB-INF/replay/Disclaimer.jsp" />
 					  -->
 				</bean>
-                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+					<property name="tagName" value="META" />
+					<property name="whereAttributeName" value="http-equiv" />
+					<property name="whereAttributeValue" value="refresh" />
 
-                        <property name="tagName" value="META" />
-                        <property name="whereAttributeName" value="http-equiv" />
-                        <property name="whereAttributeValue" value="refresh" />
-
-                        <property name="modifyAttributeName" value="content" />
-                        <property name="transformer" ref="metaRefreshHandler" />
-                </bean>
-
+					<property name="modifyAttributeName" value="content" />
+					<property name="transformer" ref="metaRefreshHandler" />
+				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="A" />
 					<property name="modifyAttributeName" value="HREF" />
 					<property name="transformer" ref="anchorURLRewriter" />
 				</bean>
-
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="IMG" />
 					<property name="modifyAttributeName" value="SRC" />
 					<property name="transformer" ref="imageURLRewriter" />
 				</bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="IMG" />
+                                        <property name="modifyAttributeName" value="SRCSET" />
+                                        <property name="transformer" ref="srcsetAttributeHandler" />
+                                </bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="SCRIPT" />
 					<property name="modifyAttributeName" value="SRC" />
 					<property name="transformer" ref="jsURLRewriter" />
 				</bean>
-
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="SCRIPT" />
+                                        <property name="modifyAttributeName" value="INTEGRITY" />
+                                        <property name="transformer" ref="integrityAttributeHandler" />
+                                </bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="BASE" />
 					<property name="modifyAttributeName" value="HREF" />
 					<property name="transformer" ref="baseHrefHandler" />
 				</bean>
-
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="modifyAttributeName" value="BACKGROUND" />
 					<property name="transformer" ref="imageURLRewriter" />
@@ -129,13 +140,10 @@
 					<property name="modifyAttributeName" value="ACTION" />
 					<property name="transformer" ref="anchorURLRewriter" />
 				</bean>
-
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
-
 					<property name="tagName" value="LINK" />
 					<property name="whereAttributeName" value="rel" />
 					<property name="whereAttributeValue" value="Stylesheet" />
-
 					<property name="modifyAttributeName" value="HREF" />
 					<property name="transformer" ref="cssURLRewriter" />
 				</bean>
@@ -151,12 +159,16 @@
 					<property name="modifyAttributeName" value="HREF" />
 					<property name="transformer" ref="anchorURLRewriter" />
 				</bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="LINK" />
+                                        <property name="modifyAttributeName" value="INTEGRITY" />
+                                        <property name="transformer" ref="integrityAttributeHandler" />
+                                </bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="AREA" />
 					<property name="modifyAttributeName" value="HREF" />
 					<property name="transformer" ref="anchorURLRewriter" />
 				</bean>
-
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="OBJECT" />
 					<property name="modifyAttributeName" value="CODEBASE" />
@@ -177,25 +189,106 @@
 					<property name="modifyAttributeName" value="ARCHIVE" />
 					<property name="transformer" ref="anchorURLRewriter" />
 				</bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="AUDIO" />
+                                        <property name="modifyAttributeName" value="SRC" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="tagName" value="EMBED" />
 					<property name="modifyAttributeName" value="SRC" />
 					<property name="transformer" ref="anchorURLRewriter" />
 				</bean>
-				<bean class="org.archive.wayback.replay.html.rules.StyleContentRule">
-					<property name="transformer" ref="cssBlockHandler" />
-				</bean>
-				<bean class="org.archive.wayback.replay.html.rules.JSContentRule">
-					<property name="transformer" ref="jsBlockHandler" />
-				</bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="modifyAttributeName" value="ONCLICK" />
 					<property name="transformer" ref="jsBlockHandler" />
 				</bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="modifyAttributeName" value="ONLOAD" />
+                                        <property name="transformer" ref="jsBlockHandler" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="modifyAttributeName" value="ONCHANGE" />
+                                        <property name="transformer" ref="jsBlockHandler" />
+                                </bean>
 				<bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
 					<property name="modifyAttributeName" value="style" />
 					<property name="transformer" ref="cssAttributeHandler" />
 				</bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="SOURCE" />
+                                        <property name="modifyAttributeName" value="SRC" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="SOURCE" />
+                                        <property name="modifyAttributeName" value="SRCSET" />
+                                        <property name="transformer" ref="srcsetAttributeHandler" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="VIDEO" />
+                                        <property name="modifyAttributeName" value="POSTER" />
+                                        <property name="transformer" ref="imageURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="VIDEO" />
+                                        <property name="modifyAttributeName" value="SRC" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.StyleContentRule">
+                                        <property name="transformer" ref="cssBlockHandler" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.JSContentRule">
+                                        <property name="transformer" ref="jsBlockHandler" />
+                                </bean>
+
+                                <!-- Experimental HTML5 data-* rewrites -->
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="DIV" />
+                                        <property name="modifyAttributeName" value="DATA-SRC" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="DIV" />
+                                        <property name="modifyAttributeName" value="DATA-URI" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="IMG" />
+                                        <property name="modifyAttributeName" value="DATA-SRC" />
+                                        <property name="transformer" ref="imageURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="LI" />
+                                        <property name="modifyAttributeName" value="DATA-SRC" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="LI" />
+                                        <property name="modifyAttributeName" value="DATA-URI" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="tagName" value="VIDEO" />
+                                        <property name="modifyAttributeName" value="DATA-SRC" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="modifyAttributeName" value="DATA-MP4" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="modifyAttributeName" value="DATA-OGG" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="modifyAttributeName" value="DATA-THUMB" />
+                                        <property name="transformer" ref="imageURLRewriter" />
+                                </bean>
+                                <bean class="org.archive.wayback.replay.html.rules.AttributeModifyingRule">
+                                        <property name="modifyAttributeName" value="DATA-WEBM" />
+                                        <property name="transformer" ref="anchorURLRewriter" />
+                                </bean>
 			</list>
 		</property>
 	</bean>


### PR DESCRIPTION
This is to fix #242 and more generally rewrite `src` attributes in tags: `<source/>`, `<video/>`, `<audio/>` and `poster` attribute in `<video/>. It also adds rewrites for more `data-*` attributes, but I am open to discussion on whether I have included rewrites I shouldn't have.

Changes made in `attribute-rewrite.properties` are for adding the rewrites to a default deployment.

Changes made in `ArchivalUrlSaxReplay.xml` are to bring it into sync with the rewrites included in  `attribute-rewrite.properties`. This file can be used by users who want to customize what gets rewritten by configuring in `ArchivalUrlReplay.xml ` the import of `ArchivalUrlSaxReplay.xml` and swapping out the `fastArchivalSAXDelegator` with `archivalSAXDelegator`.

I welcome comments on what I have included, if there are other rewrites I should have included, etc. Thanks!