### PR TITLE
Declare surefire plugin explicitly due to a change in a default value

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -19,6 +19,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 * Fix toolbar plurality issue when only a single capture. [#372](https://github.com/iipc/openwayback/issues/372)
 * Rewrite `integrity` attribute for resources that implement Subresource Integrity. [#371](https://github.com/iipc/openwayback/issues/371)
 * Upgrade httpclient from 4.3.5. [#380](https://github.com/iipc/openwayback/issues/380)
+* Declare Surefire plugin explicitly due to a change in a default value that breaks builds on newer versions of Maven. [#384](https://github.com/iipc/openwayback/pull/384)
 
 ## OpenWayback 2.3.2 Release
 ### Bug fixes

--- a/wayback-cdx-server-core/pom.xml
+++ b/wayback-cdx-server-core/pom.xml
@@ -11,6 +11,19 @@
     <packaging>jar</packaging>
     <name>Wayback CDX Server Core Java Classes</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.netpreserve.commons</groupId>

--- a/wayback-core/pom.xml
+++ b/wayback-core/pom.xml
@@ -26,6 +26,14 @@
 	  </execution>
 	</executions>
       </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+          <configuration>
+              <useSystemClassLoader>false</useSystemClassLoader>
+          </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
The default value for `useSystemClassLoader` changed between `Surefire 2.3` and `Surefire 2.4` from `false` to `true` which is breaking builds in new Maven updates. This PR declares the value back to `false` explicitly. This should fix #383.