### PR TITLE
Convert redirectURI to ASCII

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -21,6 +21,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 * Upgrade httpclient from 4.3.5. [#380](https://github.com/iipc/openwayback/issues/380)
 * Declare Surefire plugin explicitly due to a change in a default value that breaks builds on newer versions of Maven. [#384](https://github.com/iipc/openwayback/pull/384)
 * Rewrite additional HTML5 tag attributes including `source`. [#242](https://github.com/iipc/openwayback/issues/242)
+* Fix URL search with language like Arabic. [#386](https://github.com/iipc/openwayback/issues/386)
 
 ## OpenWayback 2.3.2 Release
 ### Bug fixes

--- a/wayback-core/src/main/java/org/archive/wayback/exception/BetterRequestException.java
+++ b/wayback-core/src/main/java/org/archive/wayback/exception/BetterRequestException.java
@@ -19,7 +19,12 @@
  */
 package org.archive.wayback.exception;
 
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
@@ -37,6 +42,9 @@ import org.archive.wayback.memento.MementoUtils;
  * @author brad
  */
 public class BetterRequestException extends WaybackException {
+
+	private static final Logger LOGGER =  Logger.getLogger(
+                BetterRequestException.class.getName());
 
 	private static final long serialVersionUID = 1L;
 	protected static final String ID = "betterRequest";
@@ -111,6 +119,15 @@ public class BetterRequestException extends WaybackException {
 				wbRequest.hasMementoAcceptDatetime()) {
 			redirectURI = MementoUtils.getMementoPrefix(wbRequest
 				.getAccessPoint()) + betterURI;
+		}
+		try {
+			redirectURI = new URL(redirectURI).toURI().toASCIIString();
+		} catch(MalformedURLException e) {
+			LOGGER.log(Level.WARNING, "Converting " + redirectURI +
+				" to ASCII failed", e);
+		} catch(URISyntaxException e) {
+			LOGGER.log(Level.WARNING, "Converting " + redirectURI +
+				" to ASCII failed", e);
 		}
 
 		response.setHeader("Location", redirectURI);

--- a/wayback-core/src/test/java/org/archive/wayback/exception/BetterRequestExceptionTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/exception/BetterRequestExceptionTest.java
@@ -1,0 +1,111 @@
+package org.archive.wayback.exception;
+
+import java.util.Properties;
+
+import javax.servlet.http.HttpServletResponse;
+
+import junit.framework.TestCase;
+
+import org.archive.wayback.core.WaybackRequest;
+import org.archive.wayback.memento.MementoConstants;
+import org.archive.wayback.webapp.AccessPoint;
+import org.easymock.EasyMock;
+
+/**
+ * unit test for {@link BetterRequestException}.
+ */
+public class BetterRequestExceptionTest extends TestCase {
+
+    /**
+     * Create a WaybackRequest for a Memento Timemap URI.
+     * @param mementoPrefix prefix to use for Memento requests
+     * @return new WaybackRequest
+     */
+    protected final WaybackRequest createMementoWaybackRequest(String mementoPrefix) {
+        AccessPoint accessPoint = new AccessPoint();
+        WaybackRequest wbRequest = new WaybackRequest();
+        wbRequest.setAccessPoint(accessPoint);
+        wbRequest.setMementoAcceptDatetime(true);
+        Properties configs = new Properties();
+        configs.setProperty(MementoConstants.AGGREGATION_PREFIX_CONFIG, mementoPrefix);
+        accessPoint.setConfigs(configs);
+        return wbRequest;
+    }
+
+    protected final HttpServletResponse createResponseMock() {
+        HttpServletResponse response = EasyMock.createMock(HttpServletResponse.class);
+        response.setStatus(HttpServletResponse.SC_FOUND);
+        return response;
+    }
+
+    /**
+     * Test the response location and headers are set.
+     */
+    public void testGenerateResponse() {
+        final String betterURI = "http://example.com/test";
+        final String headerName = "Vary";
+        final String headerValue = "Accept-Encoding";
+
+        HttpServletResponse response = createResponseMock();
+        response.setHeader("Location", betterURI);
+        response.setHeader(headerName, headerValue);
+        EasyMock.replay(response);
+
+        BetterRequestException bre = new BetterRequestException(betterURI);
+        bre.addHeader(headerName, headerValue);
+        bre.generateResponse(response, null);
+        EasyMock.verify(response);
+    }
+
+    /**
+     * Test the redirect URI consists of all ASCII characters.
+     */
+    public void testGenerateResponseConvertsRedirectToASCII() {
+        final String nonASCII = "http://mawdoo3.com/خاص:اتصال";
+        final String uri = "http://mawdoo3.com/%D8%AE%D8%A7%D8%B5:%D8%A7%D8%AA%D8%B5%D8%A7%D9%84";
+
+        HttpServletResponse response = createResponseMock();
+        response.setHeader("Location", uri);
+        EasyMock.replay(response);
+
+        BetterRequestException bre = new BetterRequestException(nonASCII);
+        bre.generateResponse(response, null);
+        EasyMock.verify(response);
+    }
+
+    /**
+     * Test a Memento redirect gets its prefix.
+     */
+    public void testGenerateResponseUsesMementoPrefix() {
+        final String betterURI = "/timemap/link/http://example.com";
+        final String mementoPrefix = "http://web.archive.org";
+
+        HttpServletResponse response = createResponseMock();
+        response.setHeader("Location", mementoPrefix + betterURI);
+        EasyMock.replay(response);
+        WaybackRequest wbRequest = createMementoWaybackRequest(mementoPrefix);
+
+        BetterRequestException bre = new BetterRequestException(betterURI);
+        bre.generateResponse(response, wbRequest);
+        EasyMock.verify(response);
+    }
+
+    /**
+     * Test a Memento redirect URI gets converted to ASCII.
+     */
+    public void testGenerateResponseMementoRequestToASCII() {
+        final String path = "/timemap/link/";
+        final String nonASCII = path + "http://ex.com/خاص:اتصال";
+        final String mementoPrefix = "http://web.archive.org";
+        final String uri = path + "http://ex.com/%D8%AE%D8%A7%D8%B5:%D8%A7%D8%AA%D8%B5%D8%A7%D9%84";
+
+        HttpServletResponse response = createResponseMock();
+        response.setHeader("Location", mementoPrefix + uri);
+        EasyMock.replay(response);
+        WaybackRequest wbRequest = createMementoWaybackRequest(mementoPrefix);
+
+        BetterRequestException bre = new BetterRequestException(nonASCII);
+        bre.generateResponse(response, wbRequest);
+        EasyMock.verify(response);
+    }
+}


### PR DESCRIPTION
This is intended to fix #386 by converting the redirect Location to a percent-encoded string.

Running OpenWayback in Docker with this change fixed the issue reported in #386 for me.

If anyone has a chance to try it out, let me know @loredra @ato @MohammedElsayyed 