### PR TITLE
By default disable html parsing during indexing

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -4,6 +4,11 @@
 
 Full listing of changes and bug fixes are not available prior to release 1.2.0 and between release 1.6.0 and OpenWayback 2.0.0 BETA 1 release.
 
+## OpenWayback 2.4.1 Release
+### Bug fixes
+* Don't parse HTML for tobots meta tags by default when CDX indexing. Avoids infinite loops. [#402](https://github.com/iipc/openwayback/issues/402)
+
+
 ## OpenWayback 2.4.0 Release
 ### Features
 * Add scrollbar to year chart in toolbar appearing in every archived webpage. [#340](https://github.com/iipc/openwayback/issues/340)

--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/ArcIndexer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/ArcIndexer.java
@@ -42,7 +42,8 @@ import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
 public class ArcIndexer {
 
 	private UrlCanonicalizer canonicalizer = null;
-	
+	private boolean parseHtml;
+
 	public ArcIndexer() {
 		canonicalizer = new AggressiveUrlCanonicalizer();
 	}
@@ -87,6 +88,7 @@ public class ArcIndexer {
 		ARCRecordToSearchResultAdapter adapter2 =
 			new ARCRecordToSearchResultAdapter();
 		adapter2.setCanonicalizer(canonicalizer);
+		adapter2.getAnnotater().setParseHtml(parseHtml);
 		
 		ArchiveReaderCloseableIterator itr1 = 
 			new ArchiveReaderCloseableIterator(arcReader,arcReader.iterator());
@@ -103,6 +105,10 @@ public class ArcIndexer {
 
 	public void setCanonicalizer(UrlCanonicalizer canonicalizer) {
 		this.canonicalizer = canonicalizer;
+	}
+
+	public void setParseHtml(boolean parseHtml) {
+		this.parseHtml = parseHtml;
 	}
 
 	private class ArchiveRecordToARCRecordAdapter 

--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/HTTPRecordAnnotater.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/HTTPRecordAnnotater.java
@@ -47,6 +47,8 @@ public class HTTPRecordAnnotater {
 	private final static String[] mimes = {
 		"html"
 	};
+	private boolean parseHtml;
+
 	public HTTPRecordAnnotater() {
 		rules = new ParseEventDelegator();
 		rules.init();
@@ -136,7 +138,7 @@ public class HTTPRecordAnnotater {
 		result.setMimeType(mimeType);
 		// Now the sticky part: If it looks like an HTML document, look for
 		// robot meta tags:
-		if(isHTML(mimeType)) {
+		if(parseHtml && isHTML(mimeType)) {
 			String fileContext = result.getFile() + ":" + result.getOffset();
 			annotateHTMLContent(is, encoding, fileContext, result);
 		}
@@ -172,5 +174,9 @@ public class HTTPRecordAnnotater {
 		} catch (IOException e) {
 			LOGGER.warning(fileContext + " " + e.getLocalizedMessage());
 		}
+	}
+
+	public void setParseHtml(boolean parseHtml) {
+		this.parseHtml = parseHtml;
 	}
 }

--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/IndexWorker.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/IndexWorker.java
@@ -148,6 +148,7 @@ public class IndexWorker implements Shutdownable {
 		System.err.println("FILE at CDXFILE or to STDOUT.");
 		System.err.println("With -identity, perform no url canonicalization.");
 		System.err.println("With -format, output CDX in format FORMAT.");
+		System.err.println("With -parse-html, parse HTML for robots meta tags. (Warning: can infinite loop)");
 		System.exit(1);
 	}
 	
@@ -160,6 +161,7 @@ public class IndexWorker implements Shutdownable {
 		UrlCanonicalizer canonicalizer = new AggressiveUrlCanonicalizer();
 		boolean setFormat = false;
 		boolean isIdentity = false;
+		boolean parseHtml = false;
 		String path = null;
 		if(args.length == 0) {
 			USAGE();
@@ -176,11 +178,13 @@ public class IndexWorker implements Shutdownable {
 				cdxSpec = CDXFormatIndex.CDX_HEADER_MAGIC_NEW;				
 			} else if(args[idx].equals("-format")) {
 				idx++;
-				if(idx >= args.length) {
+				if (idx >= args.length) {
 					USAGE();
 				}
 				cdxSpec = args[idx];
 				setFormat = true;
+			} else if(args[idx].equals("-parse-html")) {
+				parseHtml = true;
 			} else {
 				// either input filename:
 				if(path == null) {
@@ -206,6 +210,7 @@ public class IndexWorker implements Shutdownable {
 		IndexWorker worker = new IndexWorker();
 		worker.canonicalizer = canonicalizer;
 		worker.interval = 0;
+		worker.setParseHtml(parseHtml);
 		worker.init();
 		try {
 			CloseableIterator<CaptureSearchResult> itr = worker.indexFile(path);
@@ -321,5 +326,12 @@ public class IndexWorker implements Shutdownable {
 	 */
 	public void setCanonicalizer(UrlCanonicalizer canonicalizer) {
 		this.canonicalizer = canonicalizer;
+	}
+	/**
+	 * Sets whether HTML records should be parsed for robots meta tags.
+	 */
+	public void setParseHtml(boolean parseHtml) {
+		arcIndexer.setParseHtml(parseHtml);
+		warcIndexer.setParseHtml(parseHtml);
 	}
 }

--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/WarcIndexer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/indexer/WarcIndexer.java
@@ -37,6 +37,7 @@ public class WarcIndexer {
 
 	private UrlCanonicalizer canonicalizer = null;
 	private boolean processAll = false;
+	private boolean parseHtml;
 	public WarcIndexer() {
 		canonicalizer = new AggressiveUrlCanonicalizer();
 	}
@@ -87,6 +88,7 @@ public class WarcIndexer {
 			new WARCRecordToSearchResultAdapter();
 		adapter2.setCanonicalizer(canonicalizer);
 		adapter2.setProcessAll(processAll);
+		adapter2.getAnnotater().setParseHtml(parseHtml);
 
 		ArchiveReaderCloseableIterator itr1 = 
 			new ArchiveReaderCloseableIterator(reader,reader.iterator());
@@ -103,6 +105,10 @@ public class WarcIndexer {
 
 	public void setCanonicalizer(UrlCanonicalizer canonicalizer) {
 		this.canonicalizer = canonicalizer;
+	}
+
+	public void setParseHtml(boolean parseHtml) {
+		this.parseHtml = parseHtml;
 	}
 
 	private class ArchiveRecordToWARCRecordAdapter implements

--- a/wayback-webapp/src/main/webapp/WEB-INF/BDBCollection.xml
+++ b/wayback-webapp/src/main/webapp/WEB-INF/BDBCollection.xml
@@ -122,6 +122,9 @@
             </bean>
           </property>
           <property name="canonicalizer" ref="waybackCanonicalizer"/>
+          <!-- parsing html for robots meta tags is disabled by default to prevent infinite loops
+               https://github.com/iipc/openwayback/issues/402 -->
+          <property name="parseHtml" value="false" />
         </bean>
         
         <!-- This thread merges updates from the indexworker into the ResourceIndex -->


### PR DESCRIPTION
The HTML parser can go into an infinite loop (#402, #162). Since robotflags
are not used by most users let's disable it by default to make indexing
more reliable.

Adds a -parse-html option the cdx-indexer CLI tool to re-enable.