### PR TITLE
Avoid inserting toolbar in NOSCRIPT tag.

### DIFF
--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -7,6 +7,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 ## OpenWayback 2.4.1 Release
 ### Bug fixes
 * Don't parse HTML for robots meta tags by default when CDX indexing. Avoids infinite loops. [#402](https://github.com/iipc/openwayback/issues/402)
+* Avoid inserting toolbar in `<noscript>` when `headInsertJsp` is `null`. [#360](https://github.com/iipc/openwayback/issues/360)
 
 
 ## OpenWayback 2.4.0 Release

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
@@ -296,6 +296,7 @@ public class FastArchivalUrlReplayParseEventHandler implements
 			// it would trigger bodyInsert. We may want to revise this behavior
 			// based on real-world examples.
 			context.putData(STATE_IN_NOSCRIPT, "");
+			inNoScript = true;
 		} else if (tagName.equals(BODY_TAG) && inHead) {
 			context.putData(FERRET_IN_HEAD, null);
 			inHead = false;
@@ -545,6 +546,7 @@ public class FastArchivalUrlReplayParseEventHandler implements
 	protected void emitHeadInsert(ReplayParseContext context, Node node,
 			boolean postInsert) throws IOException {
 		String headInsert = null;
+		context.putData(FERRET_HEAD_INSERTED, FERRET_HEAD_INSERTED);
 
 		if (headInsertJsp == null) {
 			this.emit(context, null, node, null);
@@ -553,7 +555,6 @@ public class FastArchivalUrlReplayParseEventHandler implements
 
 		try {
 			headInsert = context.getJspExec().jspToString(headInsertJsp);
-			context.putData(FERRET_HEAD_INSERTED, FERRET_HEAD_INSERTED);
 		} catch (ServletException e) {
 			e.printStackTrace();
 		}

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
@@ -1089,6 +1089,39 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
 	}
 
 	/**
+	* There may not be a JSP to insert into HEAD, but we still want to
+	* avoid putting the JSP body insert into NOSCRIPT.
+	* @throws Exception
+	*/
+	public void testNOSCRIPT_noHeadInsertJsp() throws Exception {
+		delegator.setJspInsertPath("body-insert.jsp");
+		jspExec = new TestJSPExecutor();
+
+		final String input = "<!DOCTYPE html>\n" +
+				"<head>\n" +
+				"  <noscript>\n" +
+				"    <img height=\"1\" width=\"1\" style=\"display:none\" src=\"ping.gif\">\n" +
+				"  </noscript>\n" +
+				"</head>\n" +
+				"<body>\n" +
+				"  body body\n" +
+				"</body>\n" +
+				"</html>\n";
+		final String expected = "<!DOCTYPE html>\n" +
+				"<head>\n" +
+				"  <noscript>\n" +
+				"    <img height=\"1\" width=\"1\" style=\"display:none\" src=\"ping.gif\">\n" +
+				"  </noscript>\n" +
+				"</head>\n" +
+				"<body>[[[JSP-INSERT:body-insert.jsp]]]\n" +
+				"  body body\n" +
+				"</body>\n" +
+				"</html>\n";;
+		String out = doEndToEnd(input);
+		assertEquals(expected, out);
+	}
+
+	/**
 	 * pathological case of missing {@code </NOSCRIPT>}.
 	 * {@code </HEAD>} shall close </NOSCRIPT> as well.
 	 * @throws Exception


### PR DESCRIPTION
This is to fix #360 by storing that HEAD has been inserted
even when there was no `headInsertJsp`.

Despite work being done to prevent the toolbar going into `<noscript>`, it was still happening when there was no jsp for inserting into `<head>` because then the code for setting the state of being inside a <noscript> block was not being executed. @kris-sigur @ato @obrienben could one of you review this?