### PR TITLE
Add https option for Remote Resource Store configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - "git clone https://github.com/iipc/travis.git target/travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-sudo: false
-
+os: linux
+dist: bionic
 language: java
 
 jdk:
-  - oraclejdk7
-#  - oraclejdk8
+  - oraclejdk8
 
 before_install:
   - "git clone https://github.com/iipc/travis.git target/travis"
@@ -26,4 +25,3 @@ env:
   global:
     - secure: mXBn3NkZ0JtD9y5dbWtyDzTLWaHJJm7WR68MiraYb7fpj7IcKsQBNKJUsB0EO4xEHr8en05o4l9ZNi0IfywesjxT0SZ9R5iWCB1RF3/vz9pi8POyQC4Pw3O1t4pGi/IYC/9XWQvK874wigjB39kCtZ3b1Qio+EzVo97xO8fL8t4=
     - secure: phhZKVFWTUo789bQ7FvVzfCBjIMw3e8cHazdyNqq+F70sZMxLT2N0j7KLs7WcqSTXBdC+gPVNMKoCey1vSHl1eqH21SETq26GP7KjdAibbTPOgjqP8GK/CiDT1ORXk4FAsYkTbo9L+IxEECexlhabT/I6UXV/JFJE+qhaa8Wsxg=
-

--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -11,6 +11,7 @@ Full listing of changes and bug fixes are not available prior to release 1.2.0 a
 * Reduce effects of archived page CSS on replay toolbar. [#404](https://github.com/iipc/openwayback/issues/404)
 * Add minimize functionality to replay toolbar to preclude archived site navigation being covered. [#406](https://github.com/iipc/openwayback/pull/406)
 * Move CSS `<link>` tags inside of `<head>`. [#406](https://github.com/iipc/openwayback/pull/406)
+* Add capability for remote resource store to be accessed via https. [#433](https://github.com/iipc/openwayback/issues/433)
 
 ## OpenWayback 2.4.0 Release
 ### Features

--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/resourcefile/ResourceFactory.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/resourcefile/ResourceFactory.java
@@ -83,7 +83,7 @@ public class ResourceFactory {
 	throws IOException, ResourceNotAvailableException {
 		LOGGER.info("Fetching: " + urlOrPath + " : " + offset);
 		try {
-			if(urlOrPath.startsWith("http://")) {
+			if(urlOrPath.startsWith("http://") || urlOrPath.startsWith("https://")) {
 				return getResource(new URL(urlOrPath), offset);
             } else if(urlOrPath.startsWith("hdfs://") || urlOrPath.startsWith("s3://")) {           	
                 try {


### PR DESCRIPTION
Adding extra condition that checks if the remote resource store path starts with "https", to allow configuration of a remote resource store that is accessed via an https URL.

Have updated the release notes doc also.

Closes issue #433 