### PR TITLE
Remote index may not populate 'numreturned', do so explicitly

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/resourceindex/RemoteResourceIndex.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourceindex/RemoteResourceIndex.java
@@ -282,6 +282,7 @@ public class RemoteResourceIndex implements ResourceIndex {
 			throw new ResourceNotInArchiveException("No documents matching" +
 					" filter");
 		}
+		results.setReturnedCount(numAdded);
 		return results;
 	}
 	private UrlSearchResult searchElementToUrlSearchResult(Node e) {


### PR DESCRIPTION
Even if the value is included by the remote index, this is essentially free as the number of results is readily available at this point.

This has been observed to be an issue with OutbackCDX.