### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ os: linux
 dist: bionic
 language: java
 
+cache:
+  directories:
+  - $HOME/.m2
+
 jdk:
   - openjdk8
 


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.