### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,7 @@ env:
   global:
     - secure: mXBn3NkZ0JtD9y5dbWtyDzTLWaHJJm7WR68MiraYb7fpj7IcKsQBNKJUsB0EO4xEHr8en05o4l9ZNi0IfywesjxT0SZ9R5iWCB1RF3/vz9pi8POyQC4Pw3O1t4pGi/IYC/9XWQvK874wigjB39kCtZ3b1Qio+EzVo97xO8fL8t4=
     - secure: phhZKVFWTUo789bQ7FvVzfCBjIMw3e8cHazdyNqq+F70sZMxLT2N0j7KLs7WcqSTXBdC+gPVNMKoCey1vSHl1eqH21SETq26GP7KjdAibbTPOgjqP8GK/CiDT1ORXk4FAsYkTbo9L+IxEECexlhabT/I6UXV/JFJE+qhaa8Wsxg=
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
